### PR TITLE
chore: add variation name property to BKTEvaluation

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -18,7 +18,6 @@
 		0065C3CB28C7BB76002D92A2 /* BucketeerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3CA28C7BB76002D92A2 /* BucketeerTests.swift */; };
 		0065C3CC28C7BB76002D92A2 /* Bucketeer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0065C3C028C7BB76002D92A2 /* Bucketeer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0065C3DD28C7BCFF002D92A2 /* Evaluation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3DC28C7BCFF002D92A2 /* Evaluation.swift */; };
-		0065C3DF28C7BD32002D92A2 /* Variation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3DE28C7BD32002D92A2 /* Variation.swift */; };
 		0065C3E128C7BD4E002D92A2 /* Reason.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3E028C7BD4E002D92A2 /* Reason.swift */; };
 		0065C3E328C8136D002D92A2 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3E228C8136D002D92A2 /* Event.swift */; };
 		0065C3E528C813D6002D92A2 /* EventData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3E428C813D6002D92A2 /* EventData.swift */; };
@@ -181,7 +180,6 @@
 		0065C3C528C7BB76002D92A2 /* BucketeerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BucketeerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0065C3CA28C7BB76002D92A2 /* BucketeerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketeerTests.swift; sourceTree = "<group>"; };
 		0065C3DC28C7BCFF002D92A2 /* Evaluation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Evaluation.swift; sourceTree = "<group>"; };
-		0065C3DE28C7BD32002D92A2 /* Variation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Variation.swift; sourceTree = "<group>"; };
 		0065C3E028C7BD4E002D92A2 /* Reason.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reason.swift; sourceTree = "<group>"; };
 		0065C3E228C8136D002D92A2 /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
 		0065C3E428C813D6002D92A2 /* EventData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventData.swift; sourceTree = "<group>"; };
@@ -286,7 +284,6 @@
 		93AC8F7B28E34ADD00A4719B /* Poller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Poller.swift; sourceTree = "<group>"; };
 		93AC8F7D28E34B5C00A4719B /* EvaluationForegroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationForegroundTask.swift; sourceTree = "<group>"; };
 		93AC8F7F28E351C500A4719B /* ScheduledTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTask.swift; sourceTree = "<group>"; };
-		E23583D22A1CE8FA004C6862 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		949542E32A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsEventUniqueKeyTests.swift; sourceTree = "<group>"; };
 		EB2310E1209D91640023A98D /* SecondViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondViewController.swift; sourceTree = "<group>"; };
 		EB2310E3209D92570023A98D /* ThirdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdViewController.swift; sourceTree = "<group>"; };
@@ -425,7 +422,6 @@
 				0065C3E828C815F8002D92A2 /* User.swift */,
 				0065C3F228C818C0002D92A2 /* UserData.swift */,
 				0065C3F428C818EF002D92A2 /* UserEvaluations.swift */,
-				0065C3DE28C7BD32002D92A2 /* Variation.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -963,7 +959,6 @@
 				0065C3F328C818C0002D92A2 /* UserData.swift in Sources */,
 				0065C3F528C818EF002D92A2 /* UserEvaluations.swift in Sources */,
 				9340CA5928E1CD2600E690CC /* UserHolder.swift in Sources */,
-				0065C3DF28C7BD32002D92A2 /* Variation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bucketeer/Sources/Internal/Model/Evaluation.swift
+++ b/Bucketeer/Sources/Internal/Model/Evaluation.swift
@@ -6,9 +6,9 @@ struct Evaluation: Hashable, Codable {
     let featureVersion: Int
     let userId: String
     let variationId: String
-    var variation: Variation
+    let variationName: String
+    let variationValue: String
     let reason: Reason
-    var variationValue: String
 }
 
 extension Evaluation {

--- a/Bucketeer/Sources/Internal/Model/Variation.swift
+++ b/Bucketeer/Sources/Internal/Model/Variation.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-struct Variation: Codable, Hashable {
-    let id: String
-    var value: String
-    let name: String?
-    let description: String?
-}

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -17,7 +17,8 @@ final class ApiClientImpl: ApiClient {
         featureTag: String,
         defaultRequestTimeoutMills: Int64 = ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS,
         session: Session = URLSession.shared,
-        logger: Logger?) {
+        logger: Logger?
+    ) {
 
         self.apiEndpoint = apiEndpoint
         self.apiKey = apiKey

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -183,6 +183,7 @@ extension BKTClient {
             featureVersion: evaluation.featureVersion,
             userId: evaluation.userId,
             variationId: evaluation.variationId,
+            variationName: evaluation.variationName,
             variationValue: evaluation.variationValue,
             reason: BKTEvaluation.Reason(rawValue: evaluation.reason.type.rawValue) ?? .default
         )

--- a/Bucketeer/Sources/Public/BKTEvaluation.swift
+++ b/Bucketeer/Sources/Public/BKTEvaluation.swift
@@ -6,6 +6,7 @@ public struct BKTEvaluation: Equatable {
     public let featureVersion: Int
     public let userId: String
     public let variationId: String
+    public let variationName: String
     public let variationValue: String
     public let reason: Reason
 

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -263,6 +263,7 @@ final class BKTClientTests: XCTestCase {
                 featureVersion: 1,
                 userId: User.mock1.id,
                 variationId: "variation1",
+                variationName: "variation name1",
                 variationValue: "variation_value1",
                 reason: .rule
             )

--- a/BucketeerTests/E2E/BucketeerE2ETests.swift
+++ b/BucketeerTests/E2E/BucketeerE2ETests.swift
@@ -40,10 +40,11 @@ final class BucketeerE2ETests: XCTestCase {
         let actual = client.evaluationDetails(featureId: FEATURE_ID_STRING)
 
         assertEvaluation(actual: actual, expected: .init(
-            id: "feature-ios-e2e-string:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-string:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_STRING,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "349ed945-d2f9-4d04-8e83-82344cffd1ec",
+            variationName: "variation 1",
             variationValue: "value-1",
             reason: .default
         ))
@@ -59,10 +60,11 @@ final class BucketeerE2ETests: XCTestCase {
         let actual = client.evaluationDetails(featureId: FEATURE_ID_INT)
 
         assertEvaluation(actual: actual, expected: .init(
-            id: "feature-ios-e2e-integer:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-integer:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_INT,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "9c5fd2d2-d587-4ba2-8de2-0fc9454d564e",
+            variationName: "variation 10",
             variationValue: "10",
             reason: .default
         ))
@@ -78,10 +80,11 @@ final class BucketeerE2ETests: XCTestCase {
         let actual = client.evaluationDetails(featureId: FEATURE_ID_DOUBLE)
 
         assertEvaluation(actual: actual, expected: .init(
-            id: "feature-ios-e2e-double:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-double:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_DOUBLE,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "38078d8f-c6eb-4b93-9d58-c3e57010983f",
+            variationName: "variation 2.1",
             variationValue: "2.1",
             reason: .default
         ))
@@ -97,10 +100,11 @@ final class BucketeerE2ETests: XCTestCase {
         let actual = client.evaluationDetails(featureId: FEATURE_ID_BOOLEAN)
 
         assertEvaluation(actual: actual, expected: .init(
-            id: "feature-ios-e2e-bool:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-bool:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_BOOLEAN,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "4f9e0f88-e053-42a9-93e1-95d407f67021",
+            variationName: "variation true",
             variationValue: "true",
             reason: .default
         ))
@@ -117,10 +121,11 @@ final class BucketeerE2ETests: XCTestCase {
         let actual = client.evaluationDetails(featureId: FEATURE_ID_JSON)
 
         assertEvaluation(actual: actual, expected: .init(
-            id: "feature-ios-e2e-json:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-json:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_JSON,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "06f5be6b-0c79-431f-a057-822babd9d3eb",
+            variationName: "variation 1",
             variationValue: "{ \"key\": \"value-1\" }",
             reason: .default
         ))
@@ -137,10 +142,11 @@ final class BucketeerE2ETests: XCTestCase {
 
         let details = client.evaluationDetails(featureId: FEATURE_ID_STRING)
         assertEvaluation(actual: details, expected: .init(
-            id: "feature-ios-e2e-string:2:bucketeer-ios-user-id-1",
+            id: "feature-ios-e2e-string:3:bucketeer-ios-user-id-1",
             featureId: FEATURE_ID_STRING,
-            featureVersion: 2,
+            featureVersion: 3,
             variationId: "b4931643-e82f-4079-bd3c-aed02852cdd6",
+            variationName: "variation 2",
             variationValue: "value-2",
             reason: .rule
         ))

--- a/BucketeerTests/E2E/E2ETestHelpers.swift
+++ b/BucketeerTests/E2E/E2ETestHelpers.swift
@@ -82,6 +82,7 @@ struct BKTEvaluationExpected {
     var featureVersion: Int?
     var userId: String?
     var variationId: String?
+    var variationName: String?
     var variationValue: String?
     var reason: BKTEvaluation.Reason?
 }
@@ -106,6 +107,10 @@ func assertEvaluation(actual: BKTEvaluation?, expected: BKTEvaluationExpected, f
     }
     if let value = expected.variationId {
         XCTAssertEqual(actual?.variationId, value, file: file, line: line)
+        isChecked = true
+    }
+    if let value = expected.variationName {
+        XCTAssertEqual(actual?.variationName, value, file: file, line: line)
         isChecked = true
     }
     if let value = expected.variationValue {

--- a/BucketeerTests/EvaluationDaoTests.swift
+++ b/BucketeerTests/EvaluationDaoTests.swift
@@ -66,10 +66,20 @@ final class EvaluationDaoTests: XCTestCase {
         try dao.put(userId: "user1", evaluations: mocks)
 
         // Update
-        var updatedMock = Evaluation.mock1
         let updatedValue = "variation - updated"
-        updatedMock.variation.value = updatedValue
-        updatedMock.variationValue = updatedValue
+        var updatedMock = Evaluation(
+            id: "evaluation1",
+            featureId: "feature1",
+            featureVersion: 1,
+            userId: User.mock1.id,
+            variationId: "variation1",
+            variationName: "variation name1",
+            variationValue: updatedValue,
+            reason: .init(
+                type: .rule,
+                ruleId: "rule1"
+            )
+        )
         try dao.put(userId: "user1", evaluations: [updatedMock])
 
         let sql = "SELECT userId, featureId, data FROM Evaluations WHERE userId = 'user1'"
@@ -81,7 +91,6 @@ final class EvaluationDaoTests: XCTestCase {
         XCTAssertEqual(statement.string(at: 0), "user1")
         XCTAssertEqual(statement.string(at: 1), "feature1")
         let evaluation = try decoder.decode(Evaluation.self, from: statement.data(at: 2))
-        XCTAssertEqual(evaluation.variation.value, updatedValue)
         XCTAssertEqual(evaluation.variationValue, updatedValue)
 
         // End

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Bucketeer
 
+// swiftlint:disable type_body_length
 final class EvaluationInteractorTests: XCTestCase {
 
     func testFetchInitialLoad() {
@@ -369,3 +370,4 @@ final class EvaluationInteractorTests: XCTestCase {
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: "invalid_feature_id"), nil)
     }
 }
+// swiftlint:enable type_body_length

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -64,10 +64,19 @@ final class EvaluationInteractorTests: XCTestCase {
         expectation.expectedFulfillmentCount = 3
         expectation.assertForOverFulfill = true
 
-        let initialEvaluation = Evaluation.mock1
-        var updatedEvaluation = initialEvaluation
-        updatedEvaluation.variationValue += "_updated"
-
+        let updatedEvaluation = Evaluation(
+            id: "evaluation1_updated",
+            featureId: "feature1",
+            featureVersion: 1,
+            userId: User.mock1.id,
+            variationId: "variation1",
+            variationName: "variation name1",
+            variationValue: "variation_value1_updated",
+            reason: .init(
+                type: .rule,
+                ruleId: "rule1"
+            )
+        )
         let baseUserEvaluationsId = UserEvaluations.mock1.id
         let baseUserEvaluationsId_updated = baseUserEvaluationsId + "_updated"
         let api = MockApiClient(

--- a/BucketeerTests/EvaluationTests.swift
+++ b/BucketeerTests/EvaluationTests.swift
@@ -10,14 +10,9 @@ final class EvaluationTests: XCTestCase {
             featureVersion: 1,
             userId: "user",
             variationId: "variation",
-            variation: .init(
-                id: "variation",
-                value: value,
-                name: nil,
-                description: nil
-            ),
-            reason: .init(type: .default),
-            variationValue: value
+            variationName: "variation name",
+            variationValue: value,
+            reason: .init(type: .default)
         )
     }
 

--- a/BucketeerTests/Mock/MockEvaluations.swift
+++ b/BucketeerTests/Mock/MockEvaluations.swift
@@ -10,17 +10,12 @@ extension Evaluation {
         featureVersion: 1,
         userId: User.mock1.id,
         variationId: "variation1",
-        variation: .init(
-            id: "variation1",
-            value: "value1",
-            name: "name1",
-            description: "description1"
-        ),
+        variationName: "variation name1",
+        variationValue: "variation_value1",
         reason: .init(
             type: .rule,
             ruleId: "rule1"
-        ),
-        variationValue: "variation_value1"
+        )
     )
 
     /// id: evaluation2 - user: user1, value: int
@@ -30,17 +25,12 @@ extension Evaluation {
         featureVersion: 1,
         userId: User.mock1.id,
         variationId: "variation2",
-        variation: .init(
-            id: "variation2",
-            value: "2",
-            name: "name2",
-            description: "description2"
-        ),
+        variationName: "variation name2",
+        variationValue: "2",
         reason: .init(
             type: .rule,
             ruleId: "rule2"
-        ),
-        variationValue: "2"
+        )
     )
 
     /// id: evaluation3 - user: user2, value: double
@@ -50,17 +40,12 @@ extension Evaluation {
         featureVersion: 1,
         userId: User.mock2.id,
         variationId: "variation3",
-        variation: .init(
-            id: "variation3",
-            value: "3.0",
-            name: "name3",
-            description: "description3"
-        ),
+        variationName: "variation name3",
+        variationValue: "3.0",
         reason: .init(
             type: .rule,
             ruleId: "rule3"
-        ),
-        variationValue: "3.0"
+        )
     )
 
     /// id: evaluation4 - user: user2, value: bool
@@ -70,17 +55,12 @@ extension Evaluation {
         featureVersion: 1,
         userId: User.mock2.id,
         variationId: "variation4",
-        variation: .init(
-            id: "variation4",
-            value: "true",
-            name: "flag",
-            description: "description4"
-        ),
+        variationName: "variation name4",
+        variationValue: "true",
         reason: .init(
             type: .rule,
             ruleId: "rule4"
-        ),
-        variationValue: "true"
+        )
     )
 
     /// id: evaluation5 - user: user2, value: json
@@ -90,17 +70,12 @@ extension Evaluation {
         featureVersion: 1,
         userId: User.mock2.id,
         variationId: "variation5",
-        variation: .init(
-            id: "variation5",
-            value: "{ \"key\": \"value\" }",
-            name: "flag",
-            description: "description4"
-        ),
+        variationName: "variation name5",
+        variationValue: "{ \"key\": \"value\" }",
         reason: .init(
             type: .rule,
             ruleId: "rule5"
-        ),
-        variationValue: "{ \"key\": \"value\" }"
+        )
     )
 }
 

--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ build:
 build-for-testing:
 	$(BUILD_FOR_TESTING)
 
+.PHONY: lint
+lint:
+	swiftlint --strict
+
 .PHONY: test-without-building
 test-without-building:
 	$(TEST_WITHOUT_BUILDING)


### PR DESCRIPTION
Things done.

- Removed the deprecated Variation object
- Added the variation name to the BKTEvaluation object
- Updated e2e tests