### PR TITLE
chore: change the API response format to improve the response time

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -30,14 +30,13 @@
 		0065C3F328C818C0002D92A2 /* UserData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3F228C818C0002D92A2 /* UserData.swift */; };
 		0065C3F528C818EF002D92A2 /* UserEvaluations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3F428C818EF002D92A2 /* UserEvaluations.swift */; };
 		0065C3F928C81A0D002D92A2 /* JSONDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0065C3F828C81A0D002D92A2 /* JSONDecodingTests.swift */; };
-		00664C0628F9340700AB4995 /* BucketeerE2ETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00664C0528F9340700AB4995 /* BucketeerE2ETests.swift */; };
+		00664C0628F9340700AB4995 /* E2EEvaluationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00664C0528F9340700AB4995 /* E2EEvaluationTests.swift */; };
 		00664C0928FAE79100AB4995 /* E2ETestHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00664C0828FAE79100AB4995 /* E2ETestHelpers.swift */; };
 		00696D6628D1C806000068E1 /* SQLite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D6528D1C806000068E1 /* SQLite.swift */; };
 		00696D6928D1CA77000068E1 /* BKTLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D6828D1CA76000068E1 /* BKTLogger.swift */; };
 		00696D6B28D1D175000068E1 /* Migration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D6A28D1D175000068E1 /* Migration.swift */; };
-		00696D7128D1D258000068E1 /* EvaluationDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D7028D1D258000068E1 /* EvaluationDao.swift */; };
+		00696D7128D1D258000068E1 /* EvaluationStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D7028D1D258000068E1 /* EvaluationStorage.swift */; };
 		00696D7328D1D295000068E1 /* EvaluationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D7228D1D295000068E1 /* EvaluationEntity.swift */; };
-		00696D7528D1D2BB000068E1 /* EvaluationDaoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D7428D1D2BB000068E1 /* EvaluationDaoImpl.swift */; };
 		00696D9B28D21ADA000068E1 /* SQLite.Statement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D9A28D21ADA000068E1 /* SQLite.Statement.swift */; };
 		00696D9D28D21B2E000068E1 /* SQLiteEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D9C28D21B2E000068E1 /* SQLiteEntity.swift */; };
 		00696D9F28D21B46000068E1 /* AnySQLiteColumn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00696D9E28D21B46000068E1 /* AnySQLiteColumn.swift */; };
@@ -90,7 +89,7 @@
 		6B6ACE24234DDA0100BD6069 /* SecondViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B6ACE1E234DDA0100BD6069 /* SecondViewController.swift */; };
 		9322C794292CF6050040178F /* Bucketeer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0065C3BE28C7BB76002D92A2 /* Bucketeer.framework */; };
 		9322C795292CF6050040178F /* Bucketeer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0065C3BE28C7BB76002D92A2 /* Bucketeer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		9340CA0928D9D1DD00E690CC /* EvaluationDaoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA0828D9D1DD00E690CC /* EvaluationDaoTests.swift */; };
+		9340CA0928D9D1DD00E690CC /* EvaluationStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA0828D9D1DD00E690CC /* EvaluationStorageTests.swift */; };
 		9340CA1928DA0F6200E690CC /* EventDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1628DA0F6200E690CC /* EventDao.swift */; };
 		9340CA1A28DA0F6200E690CC /* EventEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1728DA0F6200E690CC /* EventEntity.swift */; };
 		9340CA1B28DA0F6200E690CC /* EventDaoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1828DA0F6200E690CC /* EventDaoImpl.swift */; };
@@ -126,11 +125,26 @@
 		947A04F82A9CF08800BE33F7 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 947A04F72A9CF08800BE33F7 /* Preview Assets.xcassets */; };
 		947A04FD2A9CF16A00BE33F7 /* Bucketeer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0065C3BE28C7BB76002D92A2 /* Bucketeer.framework */; };
 		947A04FE2A9CF16A00BE33F7 /* Bucketeer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 0065C3BE28C7BB76002D92A2 /* Bucketeer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		942AD4EB2A7EA94400348B3E /* EvaluationDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942AD4EA2A7EA94400348B3E /* EvaluationDao.swift */; };
+		942AD4ED2A7EA98900348B3E /* EvaluationSQLDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942AD4EC2A7EA98900348B3E /* EvaluationSQLDao.swift */; };
+		942AD4EF2A7EAE1200348B3E /* EvaluationStorageImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942AD4EE2A7EAE1200348B3E /* EvaluationStorageImpl.swift */; };
+		942AD4F12A7EC06D00348B3E /* EvaluationDaoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942AD4F02A7EC06D00348B3E /* EvaluationDaoTests.swift */; };
+		9433F2EE2A79745800436F91 /* EvaluationUserDefaultDaoTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9433F2ED2A79745800436F91 /* EvaluationUserDefaultDaoTest.swift */; };
+		945B9B642A7B9A7900F14934 /* E2EEventTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945B9B632A7B9A7900F14934 /* E2EEventTests.swift */; };
+		945B9B662A7B9A8800F14934 /* E2EBKTClientForceUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 945B9B652A7B9A8800F14934 /* E2EBKTClientForceUpdateTests.swift */; };
+		946540372A821A11009BF89F /* EvaluationMemCacheDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946540362A821A11009BF89F /* EvaluationMemCacheDao.swift */; };
+		946C3B152A7F929700458B9B /* MockEvaluationStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946C3B142A7F929700458B9B /* MockEvaluationStorage.swift */; };
+		946E17452A7D48A900F6D8C2 /* EvaluationUserDefaultsDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 946E17442A7D48A900F6D8C2 /* EvaluationUserDefaultsDao.swift */; };
 		949542E42A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949542E32A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift */; };
 		94B203202A970F14004C4E5D /* BKTBackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B2031F2A970F14004C4E5D /* BKTBackgroundTask.swift */; };
 		94B203222A97128B004C4E5D /* BackgroundTaskIndentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B203212A97128B004C4E5D /* BackgroundTaskIndentifier.swift */; };
 		94B203242A97142A004C4E5D /* BackgroundTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94B203232A97142A004C4E5D /* BackgroundTask.swift */; };
 		94E130F22A8DD07700120F84 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E130F12A8DD07700120F84 /* Logger.swift */; };
+		94A6896A2A861704004F4857 /* MockEvaluationUpdateListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94A689692A861704004F4857 /* MockEvaluationUpdateListener.swift */; };
+		94D1A8782A8483B4006B4851 /* InMemoryCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D1A8772A8483B4006B4851 /* InMemoryCacheTests.swift */; };
+		94F042F32A750E420060B1E4 /* EvaluationUserDefaultDaoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F042F22A750E420060B1E4 /* EvaluationUserDefaultDaoImpl.swift */; };
+		94F042F52A76BC300060B1E4 /* MockEvaluationUserDefaultsDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F042F42A76BC300060B1E4 /* MockEvaluationUserDefaultsDao.swift */; };
+		94F042F72A76C66C0060B1E4 /* UserEvaluationCondition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94F042F62A76C66C0060B1E4 /* UserEvaluationCondition.swift */; };
 		E2BE019D2A531C120040F40F /* BKTUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BE019C2A531C120040F40F /* BKTUserTests.swift */; };
 		EB2310E2209D91640023A98D /* SecondViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2310E1209D91640023A98D /* SecondViewController.swift */; };
 		EB2310E4209D92570023A98D /* ThirdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2310E3209D92570023A98D /* ThirdViewController.swift */; };
@@ -222,14 +236,13 @@
 		0065C3F228C818C0002D92A2 /* UserData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserData.swift; sourceTree = "<group>"; };
 		0065C3F428C818EF002D92A2 /* UserEvaluations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvaluations.swift; sourceTree = "<group>"; };
 		0065C3F828C81A0D002D92A2 /* JSONDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JSONDecodingTests.swift; sourceTree = "<group>"; };
-		00664C0528F9340700AB4995 /* BucketeerE2ETests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BucketeerE2ETests.swift; sourceTree = "<group>"; };
+		00664C0528F9340700AB4995 /* E2EEvaluationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EEvaluationTests.swift; sourceTree = "<group>"; };
 		00664C0828FAE79100AB4995 /* E2ETestHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2ETestHelpers.swift; sourceTree = "<group>"; };
 		00696D6528D1C806000068E1 /* SQLite.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLite.swift; sourceTree = "<group>"; };
 		00696D6828D1CA76000068E1 /* BKTLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTLogger.swift; sourceTree = "<group>"; };
 		00696D6A28D1D175000068E1 /* Migration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Migration.swift; sourceTree = "<group>"; };
-		00696D7028D1D258000068E1 /* EvaluationDao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationDao.swift; sourceTree = "<group>"; };
+		00696D7028D1D258000068E1 /* EvaluationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationStorage.swift; sourceTree = "<group>"; };
 		00696D7228D1D295000068E1 /* EvaluationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationEntity.swift; sourceTree = "<group>"; };
-		00696D7428D1D2BB000068E1 /* EvaluationDaoImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationDaoImpl.swift; sourceTree = "<group>"; };
 		00696D9A28D21ADA000068E1 /* SQLite.Statement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLite.Statement.swift; sourceTree = "<group>"; };
 		00696D9C28D21B2E000068E1 /* SQLiteEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteEntity.swift; sourceTree = "<group>"; };
 		00696D9E28D21B46000068E1 /* AnySQLiteColumn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnySQLiteColumn.swift; sourceTree = "<group>"; };
@@ -284,7 +297,7 @@
 		6B6ACE1B234DDA0000BD6069 /* FirstViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FirstViewController.swift; sourceTree = "<group>"; };
 		6B6ACE1C234DDA0000BD6069 /* SplashViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SplashViewController.swift; sourceTree = "<group>"; };
 		6B6ACE1E234DDA0100BD6069 /* SecondViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SecondViewController.swift; sourceTree = "<group>"; };
-		9340CA0828D9D1DD00E690CC /* EvaluationDaoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationDaoTests.swift; sourceTree = "<group>"; };
+		9340CA0828D9D1DD00E690CC /* EvaluationStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationStorageTests.swift; sourceTree = "<group>"; };
 		9340CA1628DA0F6200E690CC /* EventDao.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDao.swift; sourceTree = "<group>"; };
 		9340CA1728DA0F6200E690CC /* EventEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEntity.swift; sourceTree = "<group>"; };
 		9340CA1828DA0F6200E690CC /* EventDaoImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDaoImpl.swift; sourceTree = "<group>"; };
@@ -321,11 +334,26 @@
 		947A04F42A9CF08800BE33F7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		947A04F72A9CF08800BE33F7 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		947A05022A9CF17700BE33F7 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		942AD4EA2A7EA94400348B3E /* EvaluationDao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationDao.swift; sourceTree = "<group>"; };
+		942AD4EC2A7EA98900348B3E /* EvaluationSQLDao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationSQLDao.swift; sourceTree = "<group>"; };
+		942AD4EE2A7EAE1200348B3E /* EvaluationStorageImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationStorageImpl.swift; sourceTree = "<group>"; };
+		942AD4F02A7EC06D00348B3E /* EvaluationDaoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationDaoTests.swift; sourceTree = "<group>"; };
+		9433F2ED2A79745800436F91 /* EvaluationUserDefaultDaoTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationUserDefaultDaoTest.swift; sourceTree = "<group>"; };
+		945B9B632A7B9A7900F14934 /* E2EEventTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EEventTests.swift; sourceTree = "<group>"; };
+		945B9B652A7B9A8800F14934 /* E2EBKTClientForceUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = E2EBKTClientForceUpdateTests.swift; sourceTree = "<group>"; };
+		946540362A821A11009BF89F /* EvaluationMemCacheDao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationMemCacheDao.swift; sourceTree = "<group>"; };
+		946C3B142A7F929700458B9B /* MockEvaluationStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEvaluationStorage.swift; sourceTree = "<group>"; };
+		946E17442A7D48A900F6D8C2 /* EvaluationUserDefaultsDao.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EvaluationUserDefaultsDao.swift; sourceTree = "<group>"; };
 		949542E32A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsEventUniqueKeyTests.swift; sourceTree = "<group>"; };
 		94B2031F2A970F14004C4E5D /* BKTBackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTBackgroundTask.swift; sourceTree = "<group>"; };
 		94B203212A97128B004C4E5D /* BackgroundTaskIndentifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTaskIndentifier.swift; sourceTree = "<group>"; };
 		94B203232A97142A004C4E5D /* BackgroundTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundTask.swift; sourceTree = "<group>"; };
 		94E130F12A8DD07700120F84 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
+		94A689692A861704004F4857 /* MockEvaluationUpdateListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEvaluationUpdateListener.swift; sourceTree = "<group>"; };
+		94D1A8772A8483B4006B4851 /* InMemoryCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InMemoryCacheTests.swift; sourceTree = "<group>"; };
+		94F042F22A750E420060B1E4 /* EvaluationUserDefaultDaoImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationUserDefaultDaoImpl.swift; sourceTree = "<group>"; };
+		94F042F42A76BC300060B1E4 /* MockEvaluationUserDefaultsDao.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockEvaluationUserDefaultsDao.swift; sourceTree = "<group>"; };
+		94F042F62A76C66C0060B1E4 /* UserEvaluationCondition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserEvaluationCondition.swift; sourceTree = "<group>"; };
 		E2BE019C2A531C120040F40F /* BKTUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTUserTests.swift; sourceTree = "<group>"; };
 		EB2310E1209D91640023A98D /* SecondViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondViewController.swift; sourceTree = "<group>"; };
 		EB2310E3209D92570023A98D /* ThirdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdViewController.swift; sourceTree = "<group>"; };
@@ -414,10 +442,13 @@
 				006E85BC28DEAF7900B5D90D /* ApiClientTests.swift */,
 				935D9AB128F5B607007775F5 /* BKTClientTests.swift */,
 				941E007D2A4FD964002CBFBB /* BKTConfigTests.swift */,
+				9433F2ED2A79745800436F91 /* EvaluationUserDefaultDaoTest.swift */,
+				94D1A8772A8483B4006B4851 /* InMemoryCacheTests.swift */,
 				006E85DB28E026EE00B5D90D /* BKTErrorTests.swift */,
 				E2BE019C2A531C120040F40F /* BKTUserTests.swift */,
 				0065C3CA28C7BB76002D92A2 /* BucketeerTests.swift */,
-				9340CA0828D9D1DD00E690CC /* EvaluationDaoTests.swift */,
+				9340CA0828D9D1DD00E690CC /* EvaluationStorageTests.swift */,
+				942AD4F02A7EC06D00348B3E /* EvaluationDaoTests.swift */,
 				934889C628EB0ADB007BA05C /* EvaluationForegroundTaskTests.swift */,
 				006E85C228DED24500B5D90D /* EvaluationInteractorTests.swift */,
 				935D9AAF28F5B0DB007775F5 /* EvaluationTests.swift */,
@@ -481,7 +512,9 @@
 		00664C0428F933E900AB4995 /* E2E */ = {
 			isa = PBXGroup;
 			children = (
-				00664C0528F9340700AB4995 /* BucketeerE2ETests.swift */,
+				00664C0528F9340700AB4995 /* E2EEvaluationTests.swift */,
+				945B9B632A7B9A7900F14934 /* E2EEventTests.swift */,
+				945B9B652A7B9A8800F14934 /* E2EBKTClientForceUpdateTests.swift */,
 				00664C0828FAE79100AB4995 /* E2ETestHelpers.swift */,
 			);
 			path = E2E;
@@ -514,10 +547,15 @@
 		00696D6E28D1D1EE000068E1 /* Evaluation */ = {
 			isa = PBXGroup;
 			children = (
-				00696D7028D1D258000068E1 /* EvaluationDao.swift */,
-				00696D7428D1D2BB000068E1 /* EvaluationDaoImpl.swift */,
+				00696D7028D1D258000068E1 /* EvaluationStorage.swift */,
+				942AD4EE2A7EAE1200348B3E /* EvaluationStorageImpl.swift */,
 				00696D7228D1D295000068E1 /* EvaluationEntity.swift */,
 				006E85C028DECF2200B5D90D /* EvaluationInteractor.swift */,
+				94F042F22A750E420060B1E4 /* EvaluationUserDefaultDaoImpl.swift */,
+				946E17442A7D48A900F6D8C2 /* EvaluationUserDefaultsDao.swift */,
+				942AD4EA2A7EA94400348B3E /* EvaluationDao.swift */,
+				942AD4EC2A7EA98900348B3E /* EvaluationSQLDao.swift */,
+				946540362A821A11009BF89F /* EvaluationMemCacheDao.swift */,
 			);
 			path = Evaluation;
 			sourceTree = "<group>";
@@ -555,14 +593,17 @@
 				937DE96C28E4A25E00743FDB /* MockComponent.swift */,
 				937DE96628E49CE600743FDB /* MockDataModule.swift */,
 				006E85CB28DED7B500B5D90D /* MockDefaults.swift */,
+				94F042F42A76BC300060B1E4 /* MockEvaluationUserDefaultsDao.swift */,
 				9353AB4129585BF90093D1F8 /* MockDevice.swift */,
 				006E85C628DED62700B5D90D /* MockEvaluationDao.swift */,
+				946C3B142A7F929700458B9B /* MockEvaluationStorage.swift */,
 				937DE96E28E4A29000743FDB /* MockEvaluationInteractor.swift */,
 				00696DB228DB59CF000068E1 /* MockEvaluations.swift */,
 				006E85E328E034A700B5D90D /* MockEventDao.swift */,
 				937DE97028E4A2B700743FDB /* MockEventInteractor.swift */,
 				00696DAE28DB5476000068E1 /* MockEvents.swift */,
 				006E85E528E035D000B5D90D /* MockEventUpdateListener.swift */,
+				94A689692A861704004F4857 /* MockEvaluationUpdateListener.swift */,
 				006E85E128E033B000B5D90D /* MockIdGenerator.swift */,
 				006E85E728E038BC00B5D90D /* MockLogger.swift */,
 				006E85BE28DEB0A700B5D90D /* MockSession.swift */,
@@ -574,6 +615,7 @@
 		006E85A928DEA2B300B5D90D /* Remote */ = {
 			isa = PBXGroup;
 			children = (
+				94F042F82A76C7200060B1E4 /* Params */,
 				006E85B028DEAED700B5D90D /* RequestBody */,
 				006E85B528DEAF0D00B5D90D /* Response */,
 				006E85AA28DEA2BC00B5D90D /* ApiClient.swift */,
@@ -713,6 +755,14 @@
 			path = "Preview Content";
 			sourceTree = "<group>";
 		};
+        94F042F82A76C7200060B1E4 /* Params */ = {
+            isa = PBXGroup;
+            children = (
+                94F042F62A76C66C0060B1E4 /* UserEvaluationCondition.swift */,
+            );
+            path = Params;
+            sourceTree = "<group>";
+        };
 		EB5A93A12072500600A196C3 = {
 			isa = PBXGroup;
 			children = (
@@ -1012,10 +1062,12 @@
 				006E85AD28DEA2CD00B5D90D /* ApiClientImpl.swift in Sources */,
 				0047BDFF29796B8D00982361 /* ApiId.swift in Sources */,
 				004245B928F12CF000045542 /* BKTClient.swift in Sources */,
+				946E17452A7D48A900F6D8C2 /* EvaluationUserDefaultsDao.swift in Sources */,
 				9340CA6228E1F35A00E690CC /* BKTConfig.swift in Sources */,
 				006E85D628E01B0F00B5D90D /* BKTError.swift in Sources */,
 				004245BB28F12D9B00045542 /* BKTEvaluation.swift in Sources */,
 				00696D6928D1CA77000068E1 /* BKTLogger.swift in Sources */,
+				942AD4EB2A7EA94400348B3E /* EvaluationDao.swift in Sources */,
 				9340CA5B28E1CE7200E690CC /* BKTUser.swift in Sources */,
 				006E85D028DEE42E00B5D90D /* Clock.swift in Sources */,
 				9340CA5E28E1F29000E690CC /* Component.swift in Sources */,
@@ -1029,15 +1081,18 @@
 				0065C3DD28C7BCFF002D92A2 /* Evaluation.swift in Sources */,
 				94B203222A97128B004C4E5D /* BackgroundTaskIndentifier.swift in Sources */,
 				004B15FB290FBF79007F5357 /* EvaluationBackgroundTask.swift in Sources */,
-				00696D7128D1D258000068E1 /* EvaluationDao.swift in Sources */,
-				00696D7528D1D2BB000068E1 /* EvaluationDaoImpl.swift in Sources */,
+				00696D7128D1D258000068E1 /* EvaluationStorage.swift in Sources */,
+				942AD4ED2A7EA98900348B3E /* EvaluationSQLDao.swift in Sources */,
 				00696D7328D1D295000068E1 /* EvaluationEntity.swift in Sources */,
 				93AC8F7E28E34B5C00A4719B /* EvaluationForegroundTask.swift in Sources */,
+				94F042F32A750E420060B1E4 /* EvaluationUserDefaultDaoImpl.swift in Sources */,
 				006E85C128DECF2200B5D90D /* EvaluationInteractor.swift in Sources */,
+				94F042F72A76C66C0060B1E4 /* UserEvaluationCondition.swift in Sources */,
 				0065C3E328C8136D002D92A2 /* Event.swift in Sources */,
 				004CF1F32929C9E500CCC3DF /* EventBackgroundTask.swift in Sources */,
 				9340CA1928DA0F6200E690CC /* EventDao.swift in Sources */,
 				9340CA1B28DA0F6200E690CC /* EventDaoImpl.swift in Sources */,
+				946540372A821A11009BF89F /* EvaluationMemCacheDao.swift in Sources */,
 				0065C3E528C813D6002D92A2 /* EventData.swift in Sources */,
 				9340CA1A28DA0F6200E690CC /* EventEntity.swift in Sources */,
 				93AC8F7A28E33EA900A4719B /* EventForegroundTask.swift in Sources */,
@@ -1047,6 +1102,7 @@
 				006E85B928DEAF2600B5D90D /* GetEvaluationsResponse.swift in Sources */,
 				006E85DA28E01BFE00B5D90D /* GetEvaluationsResult.swift in Sources */,
 				94B203202A970F14004C4E5D /* BKTBackgroundTask.swift in Sources */,
+				942AD4EF2A7EAE1200348B3E /* EvaluationStorageImpl.swift in Sources */,
 				006E85D228DEF29F00B5D90D /* IdGenerator.swift in Sources */,
 				0065C3EB28C81620002D92A2 /* MetricsEventData.swift in Sources */,
 				0065C3ED28C8162D002D92A2 /* MetricsEventType.swift in Sources */,
@@ -1084,10 +1140,11 @@
 				006E85BD28DEAF7900B5D90D /* ApiClientTests.swift in Sources */,
 				935D9AB228F5B607007775F5 /* BKTClientTests.swift in Sources */,
 				006E85DC28E026EE00B5D90D /* BKTErrorTests.swift in Sources */,
-				00664C0628F9340700AB4995 /* BucketeerE2ETests.swift in Sources */,
+				00664C0628F9340700AB4995 /* E2EEvaluationTests.swift in Sources */,
 				0065C3CB28C7BB76002D92A2 /* BucketeerTests.swift in Sources */,
 				00664C0928FAE79100AB4995 /* E2ETestHelpers.swift in Sources */,
-				9340CA0928D9D1DD00E690CC /* EvaluationDaoTests.swift in Sources */,
+				942AD4F12A7EC06D00348B3E /* EvaluationDaoTests.swift in Sources */,
+				9340CA0928D9D1DD00E690CC /* EvaluationStorageTests.swift in Sources */,
 				934889C728EB0ADB007BA05C /* EvaluationForegroundTaskTests.swift in Sources */,
 				006E85C328DED24500B5D90D /* EvaluationInteractorTests.swift in Sources */,
 				935D9AB028F5B0DB007775F5 /* EvaluationTests.swift in Sources */,
@@ -1098,9 +1155,13 @@
 				9340CA2C28DAEA1500E690CC /* MigrationTests.swift in Sources */,
 				006E85C528DED2AC00B5D90D /* MockApiClient.swift in Sources */,
 				937DE96528E49A2C00743FDB /* MockBKTConfig.swift in Sources */,
+				94F042F52A76BC300060B1E4 /* MockEvaluationUserDefaultsDao.swift in Sources */,
+				9433F2EE2A79745800436F91 /* EvaluationUserDefaultDaoTest.swift in Sources */,
 				006E85E028E0333F00B5D90D /* MockClock.swift in Sources */,
+				945B9B662A7B9A8800F14934 /* E2EBKTClientForceUpdateTests.swift in Sources */,
 				937DE96D28E4A25E00743FDB /* MockComponent.swift in Sources */,
 				937DE96728E49CE600743FDB /* MockDataModule.swift in Sources */,
+				94D1A8782A8483B4006B4851 /* InMemoryCacheTests.swift in Sources */,
 				006E85CC28DED7B500B5D90D /* MockDefaults.swift in Sources */,
 				9353AB4229585BF90093D1F8 /* MockDevice.swift in Sources */,
 				006E85C728DED62700B5D90D /* MockEvaluationDao.swift in Sources */,
@@ -1109,7 +1170,9 @@
 				006E85E428E034A700B5D90D /* MockEventDao.swift in Sources */,
 				937DE97128E4A2B700743FDB /* MockEventInteractor.swift in Sources */,
 				00696DAF28DB5476000068E1 /* MockEvents.swift in Sources */,
+				946C3B152A7F929700458B9B /* MockEvaluationStorage.swift in Sources */,
 				949542E42A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift in Sources */,
+				94A6896A2A861704004F4857 /* MockEvaluationUpdateListener.swift in Sources */,
 				006E85E628E035D000B5D90D /* MockEventUpdateListener.swift in Sources */,
 				006E85E228E033B000B5D90D /* MockIdGenerator.swift in Sources */,
 				006E85E828E038BC00B5D90D /* MockLogger.swift in Sources */,
@@ -1118,6 +1181,7 @@
 				00696DB128DB54B4000068E1 /* MockUsers.swift in Sources */,
 				937DE95E28E4935600743FDB /* PollerTests.swift in Sources */,
 				00696DAC28D21D02000068E1 /* SQLiteTests.swift in Sources */,
+				945B9B642A7B9A7900F14934 /* E2EEventTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -16,8 +16,7 @@ final class ComponentImpl: Component {
         self.dataModule = dataModule
         self.evaluationInteractor = EvaluationInteractorImpl(
             apiClient: dataModule.apiClient,
-            evaluationDao: dataModule.evaluationDao,
-            defaults: dataModule.defaults,
+            evaluationStorage: dataModule.evaluationStorage,
             idGenerator: dataModule.idGenerator,
             featureTag: dataModule.config.featureTag
         )

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Error.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Error.swift
@@ -15,11 +15,11 @@ extension SQLite {
         var errorUserInfo: [String: Any] {
             switch self {
             case .failedToOpen(let info),
-                    .failedToPrepare(let info),
-                    .failedToStep(let info),
-                    .failedToBind(let info),
-                    .failedToFinalize(let info),
-                    .failedToExecute(let info):
+                 .failedToPrepare(let info),
+                 .failedToStep(let info),
+                 .failedToBind(let info),
+                 .failedToFinalize(let info),
+                 .failedToExecute(let info):
                 return info.userInfo
             case .unsupportedType:
                 return [NSLocalizedDescriptionKey: "Unsupported type"]
@@ -31,11 +31,11 @@ extension SQLite {
         var debugDescription: String {
             switch self {
             case .failedToOpen(let info),
-                    .failedToPrepare(let info),
-                    .failedToStep(let info),
-                    .failedToBind(let info),
-                    .failedToFinalize(let info),
-                    .failedToExecute(let info):
+                 .failedToPrepare(let info),
+                 .failedToStep(let info),
+                 .failedToBind(let info),
+                 .failedToFinalize(let info),
+                 .failedToExecute(let info):
                 return info.debugDescription
             case .unsupportedType:
                 return "Unsupported type"

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationDao.swift
@@ -1,7 +1,12 @@
 import Foundation
 
+// EvaluationDao CURD
 protocol EvaluationDao {
     func put(userId: String, evaluations: [Evaluation]) throws
     func get(userId: String) throws -> [Evaluation]
-    func deleteAllAndInsert(userId: String, evaluations: [Evaluation]) throws
+    func deleteAll(userId: String) throws
+    func deleteByIds(_ ids: [String]) throws
+    func startTransaction(block: TransactionBlock) throws
 }
+
+typealias TransactionBlock = () throws -> Void

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
@@ -1,0 +1,21 @@
+protocol KeyValueCache {
+    associatedtype DataCacheType
+    func set(key: String, value: DataCacheType)
+    func get(key: String) -> DataCacheType?
+}
+
+class InMemoryCache<T:Any> : KeyValueCache {
+    typealias DataCacheType = T
+
+    private var dict: [String : T] = [:]
+
+    func set(key: String, value: T) {
+        dict[key] = value
+    }
+
+    func get(key: String) -> T? {
+        return dict[key]
+    }
+}
+
+final class EvaluationMemCacheDao: InMemoryCache<[Evaluation]> {}

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationSQLDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationSQLDao.swift
@@ -1,10 +1,12 @@
-final class EvaluationDaoImpl: EvaluationDao {
+final class EvaluationSQLDao: EvaluationDao {
+
     private let db: SQLite
 
     init(db: SQLite) {
         self.db = db
     }
 
+    // noted: userId is unused, should we remove it?
     func put(userId: String, evaluations: [Evaluation]) throws {
         let entities = try evaluations.map {
             try EvaluationEntity(model: $0)
@@ -16,11 +18,19 @@ final class EvaluationDaoImpl: EvaluationDao {
         try db.select(EvaluationEntity(), conditions: [.equal(column: "userId", value: userId)])
     }
 
-    func deleteAllAndInsert(userId: String, evaluations: [Evaluation]) throws {
-        let entities = try evaluations.map {
-            try EvaluationEntity(model: $0)
-        }
+    func deleteAll(userId: String) throws {
         try db.delete(EvaluationEntity(), condition: .equal(column: "userId", value: userId))
-        try db.insert(entities)
+    }
+
+    func deleteByIds(_ ids: [String]) throws {
+        for id in ids {
+            try db.delete(EvaluationEntity(), condition: .equal(column: "id", value: id))
+        }
+    }
+
+    func startTransaction(block: () throws -> Void) throws {
+        try db.startTransaction {
+            try block()
+        }
     }
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+protocol EvaluationStorage {
+    func getBy(userId: String, featureId: String) -> Evaluation?
+    func get(userId: String) throws -> [Evaluation]
+    // force update
+    func deleteAllAndInsert(userId: String, evaluations: [Evaluation], evaluatedAt: String) throws
+    // upsert
+    @discardableResult func update(evaluations: [Evaluation], archivedFeatureIds: [String], evaluatedAt: String) throws -> Bool
+    func refreshCache() throws
+
+    var currentEvaluationsId: String { get }
+    var featureTag: String { get }
+    // expected set evaluatedAt from `deleteAllAndInsert` or `update` only
+    var evaluatedAt: String { get }
+    var userAttributesUpdated: Bool { get }
+
+    func setCurrentEvaluationsId(value: String)
+    func setFeatureTag(value: String)
+    func setEvaluatedAt(value: String)
+    func setUserAttributesUpdated(value: Bool)
+}

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -1,0 +1,127 @@
+final class EvaluationStorageImpl: EvaluationStorage {
+
+    var currentEvaluationsId: String {
+        get {
+            return evaluationUserDefaultsDao.currentEvaluationsId
+        }
+        set {
+            evaluationUserDefaultsDao.setCurrentEvaluationsId(value: newValue)
+        }
+    }
+
+    var featureTag: String {
+        get {
+            return evaluationUserDefaultsDao.featureTag
+        }
+        set {
+            evaluationUserDefaultsDao.setFeatureTag(value: newValue)
+        }
+    }
+
+    var evaluatedAt: String {
+        get {
+            return evaluationUserDefaultsDao.evaluatedAt
+        }
+        set {
+            evaluationUserDefaultsDao.setEvaluatedAt(value: newValue)
+        }
+    }
+
+    var userAttributesUpdated: Bool {
+        get {
+            return evaluationUserDefaultsDao.userAttributesUpdated
+        }
+        set {
+            evaluationUserDefaultsDao.setUserAttributesUpdated(value: newValue)
+        }
+    }
+
+    private let userId: String
+    // Expected SQL Dao
+    private let evaluationDao: EvaluationDao
+    // Expected in-memory cache Dao
+    private let evaluationMemCacheDao: EvaluationMemCacheDao
+    private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
+
+    init(
+        userId: String,
+        evaluationDao: EvaluationDao,
+        evaluationMemCacheDao: EvaluationMemCacheDao,
+        evaluationUserDefaultsDao: EvaluationUserDefaultsDao
+    ) {
+        self.userId = userId
+        self.evaluationDao = evaluationDao
+        self.evaluationUserDefaultsDao = evaluationUserDefaultsDao
+        self.evaluationMemCacheDao = evaluationMemCacheDao
+        try? refreshCache()
+    }
+
+    func get(userId: String) throws -> [Evaluation] {
+        evaluationMemCacheDao.get(key: userId) ?? []
+    }
+
+    func deleteAllAndInsert(userId: String, evaluations: [Evaluation], evaluatedAt: String) throws {
+        try evaluationDao.startTransaction {
+            try evaluationDao.deleteAll(userId: userId)
+            try evaluationDao.put(userId: userId, evaluations: evaluations)
+        }
+        // Update cache directly after we have force update
+        evaluationMemCacheDao.set(key: userId, value: evaluations)
+        self.evaluatedAt = evaluatedAt
+    }
+
+    func update(evaluations: [Evaluation], archivedFeatureIds: [String], evaluatedAt: String) throws -> Bool {
+        var activeEvaluations = [Evaluation]()
+        var archivedEvaluationIds = [String]()
+        try evaluationDao.startTransaction {
+            // 1. Update evaluation with new data
+            try evaluationDao.put(userId: userId, evaluations: evaluations)
+            // 2. Get current data in db
+            let evaluationsInDb = try evaluationDao.get(userId: userId)
+            // 3. Filter active & archived
+            for evaluation in evaluationsInDb {
+                if archivedFeatureIds.contains(evaluation.featureId) {
+                    archivedEvaluationIds.append(evaluation.id)
+                } else {
+                    activeEvaluations.append(evaluation)
+                }
+            }
+            // 4. Remove all the evaluations which have the same id in the list archivedEvaluationIds
+            if (archivedEvaluationIds.count > 0) {
+                try evaluationDao.deleteByIds(archivedEvaluationIds)
+            }
+        }
+        self.evaluatedAt = evaluatedAt
+        // 5. Save a new cache
+        evaluationMemCacheDao.set(key: userId, value: activeEvaluations)
+        return evaluations.count > 0 || archivedEvaluationIds.count > 0
+    }
+
+    // getBy will return the data from the cache to speed up the response time
+    func getBy(userId: String, featureId: String) -> Evaluation? {
+        return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
+            evaluation.featureId == featureId
+        } ?? nil
+    }
+
+    func refreshCache() throws {
+        let evaluationsInDb = try evaluationDao.get(userId: userId)
+        evaluationMemCacheDao.set(key: userId, value: evaluationsInDb)
+    }
+
+    func setCurrentEvaluationsId(value: String) {
+        currentEvaluationsId = value
+    }
+
+    func setFeatureTag(value: String) {
+        featureTag = value
+    }
+
+    func setEvaluatedAt(value: String) {
+        evaluatedAt = value
+    }
+
+    func setUserAttributesUpdated(value: Bool) {
+        userAttributesUpdated = value
+    }
+}

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+class EvaluationUserDefaultDaoImpl: EvaluationUserDefaultsDao {
+    private static let userEvaluationsIdKey = "bucketeer_user_evaluations_id"
+    private static let featureTagKey = "bucketeer_feature_tag"
+    private static let evaluatedAtKey = "bucketeer_evaluated_at"
+    private static let userAttributesUpdatedKey = "bucketeer_user_attributes_updated"
+    private let defs: Defaults
+
+    init(defaults: Defaults) {
+        defs = defaults
+    }
+
+    var userAttributesUpdated: Bool {
+        get {
+            return defs.bool(forKey: Self.userAttributesUpdatedKey)
+        }
+        set {
+            defs.set(newValue, forKey: Self.userAttributesUpdatedKey)
+        }
+    }
+    var currentEvaluationsId: String {
+        get {
+            return defs.string(forKey: Self.userEvaluationsIdKey) ?? ""
+        }
+        set {
+            defs.set(newValue, forKey: Self.userEvaluationsIdKey)
+        }
+    }
+    var featureTag: String {
+        get {
+            return defs.string(forKey: Self.featureTagKey) ?? ""
+        }
+        set {
+            defs.set(newValue, forKey: Self.featureTagKey)
+        }
+    }
+    var evaluatedAt: String {
+        get {
+            return defs.string(forKey: Self.evaluatedAtKey) ?? "0"
+        }
+        set {
+            defs.set(newValue, forKey: Self.evaluatedAtKey)
+        }
+    }
+
+    func setCurrentEvaluationsId(value: String) {
+        currentEvaluationsId = value
+    }
+
+    func setFeatureTag(value: String) {
+        featureTag = value
+    }
+
+    func setEvaluatedAt(value: String) {
+        evaluatedAt = value
+    }
+
+    func setUserAttributesUpdated(value: Bool) {
+        userAttributesUpdated = value
+    }
+}

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultsDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultsDao.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+protocol EvaluationUserDefaultsDao {
+    var currentEvaluationsId: String { get }
+    var featureTag: String { get }
+    var evaluatedAt: String { get }
+    var userAttributesUpdated: Bool { get }
+
+    func setCurrentEvaluationsId(value: String)
+    func setFeatureTag(value: String)
+    func setEvaluatedAt(value: String)
+    func setUserAttributesUpdated(value: Bool)
+}

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -202,10 +202,10 @@ final class EventInteractorImpl: EventInteractor {
         ])
     }
 
-    private func trackMetricsEvent(events : [Event]) throws {
+    private func trackMetricsEvent(events: [Event]) throws {
         // We will add logic to filter duplicate metrics event here
         let storedEvents = try eventDao.getEvents()
-        let metricsEventUniqueKeys : [String] = storedEvents.filter { item in
+        let metricsEventUniqueKeys: [String] = storedEvents.filter { item in
             return item.isMetricEvent()
         }.map { item in
             return item.uniqueKey()
@@ -213,7 +213,7 @@ final class EventInteractorImpl: EventInteractor {
         let newEvents = events.filter { item in
             return item.isMetricEvent() && !metricsEventUniqueKeys.contains(item.uniqueKey())
         }
-        if (newEvents.count > 0) {
+        if newEvents.count > 0 {
             try eventDao.add(events: newEvents)
             updateEventsAndNotify()
         } else {

--- a/Bucketeer/Sources/Internal/Model/UserEvaluations.swift
+++ b/Bucketeer/Sources/Internal/Model/UserEvaluations.swift
@@ -1,6 +1,10 @@
 import Foundation
 
-struct UserEvaluations: Codable {
+struct UserEvaluations: Hashable, Codable {
+    // note: should check if we could using `let`
     var id: String
     var evaluations: [Evaluation]
+    let createdAt: String
+    let forceUpdate: Bool
+    let archivedFeatureIds: [String]
 }

--- a/Bucketeer/Sources/Internal/Remote/ApiClient.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClient.swift
@@ -1,16 +1,27 @@
 import Foundation
 
 protocol ApiClient {
-    func getEvaluations(user: User, userEvaluationsId: String, timeoutMillis: Int64?, completion: ((GetEvaluationsResult) -> Void)?)
+    func getEvaluations(
+        user: User,
+        userEvaluationsId: String,
+        timeoutMillis: Int64?,
+        condition: UserEvaluationCondition,
+        completion: ((GetEvaluationsResult) -> Void)?
+    )
     func registerEvents(events: [Event], completion: ((Result<RegisterEventsResponse, BKTError>) -> Void)?)
 }
 
 extension ApiClient {
-    func getEvaluations(user: User, userEvaluationsId: String, completion: ((GetEvaluationsResult) -> Void)?) {
+    func getEvaluations(
+        user: User,
+        userEvaluationsId: String,
+        condition: UserEvaluationCondition,
+        completion: ((GetEvaluationsResult) -> Void)?) {
         getEvaluations(
             user: user,
             userEvaluationsId: userEvaluationsId,
             timeoutMillis: nil,
+            condition: condition,
             completion: completion
         )
     }

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -36,13 +36,20 @@ final class ApiClientImpl: ApiClient {
         self.session.configuration.timeoutIntervalForRequest = TimeInterval(self.defaultRequestTimeoutMills) / 1000
     }
 
-    func getEvaluations(user: User, userEvaluationsId: String, timeoutMillis: Int64?, completion: ((GetEvaluationsResult) -> Void)?) {
+    func getEvaluations(
+        user: User,
+        userEvaluationsId: String,
+        timeoutMillis: Int64?,
+        condition: UserEvaluationCondition,
+        completion: ((GetEvaluationsResult) -> Void)?) {
         let startAt = Date()
         let requestBody = GetEvaluationsRequestBody(
             tag: self.featureTag,
             user: user,
             userEvaluationsId: userEvaluationsId,
-            sourceId: .ios
+            sourceId: .ios,
+            userEvaluationCondition: UserEvaluationCondition(evaluatedAt: condition.evaluatedAt,
+                                                             userAttributesUpdated: condition.userAttributesUpdated)
         )
         let featureTag = self.featureTag
         let timeoutMillisValue = timeoutMillis ?? defaultRequestTimeoutMills

--- a/Bucketeer/Sources/Internal/Remote/Params/UserEvaluationCondition.swift
+++ b/Bucketeer/Sources/Internal/Remote/Params/UserEvaluationCondition.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct UserEvaluationCondition: Codable {
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // evaluatedAt: the last time the user was evaluated. The server will return in the get_evaluations response (UserEvaluations.CreatedAt), and it must be saved in the client
+    // userAttributesUpdated: when the user attributes change via the customAttributes interface, the userAttributesUpdated field must be set to true in the next request.
+    let evaluatedAt: String?
+    let userAttributesUpdated: Bool
+}

--- a/Bucketeer/Sources/Internal/Remote/RequestBody/GetEvaluationsRequestBody.swift
+++ b/Bucketeer/Sources/Internal/Remote/RequestBody/GetEvaluationsRequestBody.swift
@@ -5,4 +5,5 @@ struct GetEvaluationsRequestBody: Codable {
     let user: User
     let userEvaluationsId: String
     let sourceId: SourceID
+    let userEvaluationCondition: UserEvaluationCondition
 }

--- a/Bucketeer/Sources/Internal/Utils/Defaults.swift
+++ b/Bucketeer/Sources/Internal/Utils/Defaults.swift
@@ -2,6 +2,7 @@ import Foundation
 
 protocol Defaults {
     func string(forKey defaultName: String) -> String?
+    func bool(forKey defaultName: String) -> Bool
     func set(_ value: Any?, forKey defaultName: String)
 }
 

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -97,9 +97,6 @@ extension BKTConfig {
         guard let apiEndpointURL = URL(string: apiEndpoint) else {
             throw BKTError.illegalArgument(message: "apiEndpoint is required")
         }
-        guard !featureTag.isEmpty else {
-            throw BKTError.illegalArgument(message: "featureTag is required")
-        }
         guard !appVersion.isEmpty else {
             throw BKTError.illegalArgument(message: "appVersion is required")
         }
@@ -138,23 +135,23 @@ extension BKTConfig {
         guard let apiEndpoint = builder.apiEndpoint, apiEndpoint.isNotEmpty() else {
             throw BKTError.illegalArgument(message: "apiEndpoint is required")
         }
-        guard let featureTag = builder.featureTag, featureTag.isNotEmpty() else {
-            throw BKTError.illegalArgument(message: "featureTag is required")
-        }
         guard let appVersion = builder.appVersion, appVersion.isNotEmpty() else {
             throw BKTError.illegalArgument(message: "appVersion is required")
         }
 
         // Set default intervals if needed
-        let pollingInterval : Int64 = builder.pollingInterval ?? Constant.MINIMUM_POLLING_INTERVAL_MILLIS
-        let backgroundPollingInterval : Int64 = builder.backgroundPollingInterval ?? Constant.MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS
+        let pollingInterval: Int64 = builder.pollingInterval ?? Constant.MINIMUM_POLLING_INTERVAL_MILLIS
+        let backgroundPollingInterval: Int64 = builder.backgroundPollingInterval ?? Constant.MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS
         let eventsFlushInterval: Int64 = builder.eventsFlushInterval ?? Constant.DEFAULT_FLUSH_INTERVAL_MILLIS
         let eventsMaxQueueSize = builder.eventsMaxQueueSize ?? Constant.DEFAULT_MAX_QUEUE_SIZE
 
         // Use the current init method
         try self.init(apiKey: apiKey,
                       apiEndpoint: apiEndpoint,
-                      featureTag: featureTag,
+                      // refs: JS SDK PR https://github.com/bucketeer-io/javascript-client-sdk/pull/91
+                      // Allow Builder.featureTag could be nill
+                      // So the default value of the BKTConfig will be ""
+                      featureTag: builder.featureTag ?? "",
                       eventsFlushInterval: eventsFlushInterval,
                       eventsMaxQueueSize: eventsMaxQueueSize,
                       pollingInterval: pollingInterval,

--- a/BucketeerTests/BKTConfigTests.swift
+++ b/BucketeerTests/BKTConfigTests.swift
@@ -160,7 +160,12 @@ final class BKTConfigTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
 
-    func testFeaturedRequired() {
+    func testFeaturedTagIsOptional() {
+        // https://github.com/bucketeer-io/android-client-sdk/issues/69
+        // Change the featureTag setting to be optional in the BKTConfig
+        // featured_tag is no longer required, it could be null when using `BKTConfig.Builder`
+        // when we did not set feature_tag on the Builder
+        // the value of BKTConfig.feature_tag should be empty string ""
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 2
         let builders = [
@@ -177,10 +182,11 @@ final class BKTConfigTests: XCTestCase {
 
         builders.forEach { builder in
             do {
-                _ = try builder.build()
-            } catch BKTError.illegalArgument(let message) {
-                XCTAssertEqual("featureTag is required", message)
+                let config = try builder.build()
+                XCTAssertEqual(config.featureTag, "", "explicitly passing nil or empty string to featureTag results in empty string")
                 expectation.fulfill()
+            } catch BKTError.illegalArgument(let message) {
+                XCTAssertEqual("builder.build() should success", message)
             } catch {
                 print("Unexpected error: \(error).")
                 XCTFail("Unexpected error: \(error).")

--- a/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
+++ b/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
@@ -1,0 +1,174 @@
+import Foundation
+import XCTest
+@testable import Bucketeer
+
+@available(iOS 13, *)
+final class E2EBKTClientForceUpdateTests: XCTestCase {
+
+    private var config: BKTConfig!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        UserDefaults.standard.removeObject(forKey: "bucketeer_feature_tag")
+        UserDefaults.standard.removeObject(forKey: "bucketeer_evaluatedAt")
+        UserDefaults.standard.removeObject(forKey: "bucketeer_userAttributesUpdated")
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        try await BKTClient.shared.flush()
+        try BKTClient.destroy()
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        try FileManager.default.removeItem(at: .database)
+    }
+
+    // "userEvaluationsId is different and evaluatedAt is too old"
+    func testUserEvaluationsIdMismatchAndEvaluatedAtTooOld () async throws {
+        let config = try BKTConfig.e2e()
+        let user = try BKTUser.Builder().with(id: USER_ID).build()
+
+        let internalDataModule = try DataModuleImpl(user: user.toUser(), config: config)
+        var internalEvaluationStorage = internalDataModule.evaluationStorage
+        let userId = USER_ID
+        let tobeDeletedEvaluation = Evaluation(
+            id: "evaluation1",
+            featureId: "feature1",
+            featureVersion: 1,
+            userId: USER_ID,
+            variationId: "variation1",
+            variationName: "variation name1",
+            variationValue: "variation_value1",
+            reason: .init(
+                type: .rule,
+                ruleId: "rule1"
+            )
+        )
+        let randomUserEvaluationId = "3227641913513702639"
+        let tooOldEvaluatedAt = "1"
+        // Prefill data
+        internalEvaluationStorage.setCurrentEvaluationsId(value: randomUserEvaluationId)
+        try internalEvaluationStorage.deleteAllAndInsert(
+            userId: userId,
+            evaluations: [tobeDeletedEvaluation],
+            evaluatedAt: tooOldEvaluatedAt
+        )
+
+        XCTAssertEqual(internalEvaluationStorage.evaluatedAt, tooOldEvaluatedAt)
+        XCTAssertEqual(internalEvaluationStorage.currentEvaluationsId, randomUserEvaluationId)
+
+        let evaluations = try internalEvaluationStorage.get(userId: userId)
+        XCTAssertEqual(evaluations, [tobeDeletedEvaluation], "We should have `tobeDeletedEvaluation` on the cache")
+
+        // note: we need prepare the context before initialize the BKTClient
+        // because on initialize() the BKTClient will auto fetch the evalutation
+        try await BKTClient.initialize(
+            config: config,
+            user: user
+        )
+        let client = try BKTClient.shared
+        guard let component = client.component as? ComponentImpl else {
+            XCTFail("could not access client.component")
+            return
+        }
+
+        let evaluationStorage = component.dataModule.evaluationStorage
+        XCTAssertNotEqual(evaluationStorage.evaluatedAt, tooOldEvaluatedAt)
+        XCTAssertNotEqual(evaluationStorage.currentEvaluationsId, randomUserEvaluationId)
+
+        let currentEvaluations = try evaluationStorage.get(userId: userId)
+        XCTAssertEqual(currentEvaluations.isEmpty, false)
+        XCTAssertFalse(currentEvaluations.contains(tobeDeletedEvaluation), "we should not have `tobeDeletedEvaluation` in the cache")
+    }
+
+    // userEvaluationId is empty after feature_tag changed
+    func testInitializeWithNewFeatureTag() async throws {
+        let config = try BKTConfig.e2e(featureTag: "android")
+        let userId = USER_ID
+        let user = try BKTUser.Builder().with(id: userId).build()
+        try await BKTClient.initialize(
+            config: config,
+            user: user
+        )
+        let client = try BKTClient.shared
+
+        guard let component = client.component as? ComponentImpl else {
+            XCTFail("could not access client.component")
+            return
+        }
+
+        let evaluationStorage = component.dataModule.evaluationStorage
+        XCTAssertNotEqual(evaluationStorage.evaluatedAt, "0")
+        XCTAssertNotEqual(evaluationStorage.currentEvaluationsId, "")
+
+        let currentEvaluations = try evaluationStorage.get(userId: USER_ID)
+        XCTAssertEqual(currentEvaluations.isEmpty, false)
+
+        let tobeDeletedEvaluation = Evaluation(
+            id: "evaluation1",
+            featureId: "feature1",
+            featureVersion: 1,
+            userId: USER_ID,
+            variationId: "variation1",
+            variationName: "variation name1",
+            variationValue: "variation_value1",
+            reason: .init(
+                type: .rule,
+                ruleId: "rule1"
+            )
+        )
+
+        try evaluationStorage.update(evaluations: [tobeDeletedEvaluation], archivedFeatureIds: [], evaluatedAt: "1")
+        let currentEvaluationsWithFakeData = try evaluationStorage.get(userId: USER_ID)
+        XCTAssertEqual(currentEvaluationsWithFakeData.count, currentEvaluations.count + 1)
+        XCTAssertEqual(currentEvaluationsWithFakeData.contains(tobeDeletedEvaluation), true)
+
+        // Similate feature_tag changed
+        try DispatchQueue.main.sync {
+            try BKTClient.destroy()
+        }
+
+        let configWithFeatureTag = try BKTConfig.e2e(featureTag: FEATURE_TAG)
+        try await BKTClient.initialize(
+            config: configWithFeatureTag,
+            user: user
+        )
+        let clientWithFeatureTag = try BKTClient.shared
+
+        guard let componentWithFeatureTag = clientWithFeatureTag.component as? ComponentImpl else {
+            XCTFail("could not access clientWithFeatureTag.component")
+            return
+        }
+
+        let evaluationStorageWithFeatureTag = componentWithFeatureTag.dataModule.evaluationStorage
+        XCTAssertNotEqual(evaluationStorageWithFeatureTag.currentEvaluationsId, "")
+        XCTAssertNotEqual(client.component.evaluationInteractor.currentEvaluationsId, "")
+
+        let currentEvaluationsWithOutFakeData = try evaluationStorageWithFeatureTag.get(userId: USER_ID)
+        // verify if `force_update` happened
+        // if true , `tobeDeletedEvaluation` will no longer found in the cache
+        XCTAssertEqual(currentEvaluationsWithOutFakeData.contains(tobeDeletedEvaluation), false)
+    }
+
+    func testInitWithoutFeatureTagShouldRetrievesAllFeatures() async throws {
+        let config = try BKTConfig.e2e(featureTag: "")
+        let userId = USER_ID
+        let user = try BKTUser.Builder().with(id: userId).build()
+        try await BKTClient.initialize(
+            config: config,
+            user: user
+        )
+        let client = try BKTClient.shared
+
+        let android = client.evaluationDetails(featureId: "feature-android-e2e-string")
+        XCTAssertNotNil(android)
+        let golang = client.evaluationDetails(featureId: "feature-go-server-e2e-1")
+        XCTAssertNotNil(golang)
+        let javascript = client.evaluationDetails(featureId: "feature-js-e2e-string")
+        XCTAssertNotNil(javascript)
+    }
+}

--- a/BucketeerTests/E2E/E2EEvaluationTests.swift
+++ b/BucketeerTests/E2E/E2EEvaluationTests.swift
@@ -3,7 +3,7 @@ import XCTest
 import Bucketeer
 
 @available(iOS 13, *)
-final class BucketeerE2ETests: XCTestCase {
+final class E2EEvaluationTests: XCTestCase {
 
     private var config: BKTConfig!
 

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import XCTest
+import Bucketeer
+
+@available(iOS 13, *)
+final class E2EEventTests: XCTestCase {
+
+    private var config: BKTConfig!
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+
+        let config = try BKTConfig.e2e()
+        let user = try BKTUser.Builder().with(id: USER_ID).build()
+        try await BKTClient.initialize(
+            config: config,
+            user: user
+        )
+    }
+
+    @MainActor
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        try await BKTClient.shared.flush()
+        try BKTClient.destroy()
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        try FileManager.default.removeItem(at: .database)
+    }
+
+    func testTrack() async throws {
+        do {
+            let client = try BKTClient.shared
+            client.assert(expectedEventCount: 2)
+            client.track(goalId: GOAL_ID, value: GOAL_VALUE)
+            try await Task.sleep(nanoseconds: 1_000_000)
+            client.assert(expectedEventCount: 3)
+            try await client.flush()
+            client.assert(expectedEventCount: 0)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+}

--- a/BucketeerTests/E2E/E2ETestHelpers.swift
+++ b/BucketeerTests/E2E/E2ETestHelpers.swift
@@ -16,13 +16,14 @@ let GOAL_VALUE = 1.0
 
 @available(iOS 13, *)
 extension BKTConfig {
-    static func e2e() throws -> BKTConfig {
+    static func e2e(featureTag: String = FEATURE_TAG) throws -> BKTConfig {
         let apiKey = ProcessInfo.processInfo.environment["E2E_API_KEY"]!
         let apiEndpoint = ProcessInfo.processInfo.environment["E2E_API_ENDPOINT"]!
+
         let builder = BKTConfig.Builder()
             .with(apiKey: apiKey)
             .with(apiEndpoint: apiEndpoint)
-            .with(featureTag: FEATURE_TAG)
+            .with(featureTag: featureTag)
             .with(appVersion: "1.2.3")
             .with(logger: E2ELogger())
 
@@ -155,5 +156,19 @@ extension URL {
             .url(for: DatabaseOpenHelper.directory, in: .userDomainMask, appropriateFor: nil, create: true)
         return directoryURL.appendingPathComponent(Constant.DB.FILE_NAME)
         // swiftlint:enable force_try
+    }
+}
+
+final class MockAsyncEventUpdateListener: EvaluationUpdateListener {
+    private var mockContinuation: CheckedContinuation< Bool, Error>?
+
+    @discardableResult
+    func waitForOnUpdateEvent() async throws -> Bool {
+        return try await withCheckedThrowingContinuation { continuation in
+            mockContinuation = continuation
+        }
+    }
+    func onUpdate() {
+        mockContinuation?.resume(returning: true)
     }
 }

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -1,42 +1,91 @@
 import XCTest
 @testable import Bucketeer
 
-// swiftlint:disable type_body_length
+// swiftlint:disable type_body_length file_length
 final class EvaluationInteractorTests: XCTestCase {
 
     func testFetchInitialLoad() {
-        let expectation = XCTestExpectation()
-        expectation.expectedFulfillmentCount = 2
+        let testFetchInitialLoadExpectation = XCTestExpectation(description: "testFetchInitialLoad")
+        testFetchInitialLoadExpectation.expectedFulfillmentCount = 6
+        testFetchInitialLoadExpectation.assertForOverFulfill = true
 
         let baseUserEvaluationsId = UserEvaluations.mock1.id
+        let evaluationCreatedAt = UserEvaluations.mock1.createdAt
         let api = MockApiClient(
-            getEvaluationsHandler: { user, userEvaluationsId, _, completion in
-
+            getEvaluationsHandler: { user, userEvaluationsId, _, condition, completion in
                 XCTAssertEqual(user, .mock1)
                 XCTAssertEqual(userEvaluationsId, "")
-
+                XCTAssertEqual(condition.evaluatedAt, "0", "evaluationCreatedAt should be `0`")
+                XCTAssertEqual(condition.userAttributesUpdated, false, "userAttributesUpdated should be false")
                 let response = GetEvaluationsResponse(
                     evaluations: .mock1,
                     userEvaluationsId: baseUserEvaluationsId
                 )
                 completion?(.success(response))
-                expectation.fulfill()
+                testFetchInitialLoadExpectation.fulfill()
             }
         )
 
-        let dao = MockEvaluationDao()
-        let defaults = MockDefaults()
+        let storage = MockEvaluationStorage(updateHandler: { evaluations, archivedFeatureIds, evaluatedAt in
+            testFetchInitialLoadExpectation.fulfill()
+            XCTAssertEqual(evaluations, [.mock1, .mock2])
+            XCTAssertEqual(archivedFeatureIds, [])
+            XCTAssertEqual(evaluatedAt, UserEvaluations.mock1.createdAt)
+            return true
+        }, deleteAllAndInsertHandler: { _, _ in
+            XCTFail("`deleteAllAndInsertHandler` should not called ")
+        }, getByFeatureIdHandler: { _, featureId in
+            testFetchInitialLoadExpectation.fulfill()
+            if featureId == Evaluation.mock1.featureId {
+                return .mock1
+            }
+            if featureId == Evaluation.mock2.featureId {
+                return .mock2
+            }
+            return nil
+        })
+
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
+
+        _ = interactor.addUpdateListener(listener: MockEvaluationUpdateListener(handler: {
+            // Check if listener is called if we have something new
+            testFetchInitialLoadExpectation.fulfill()
+        }))
+
+        // https://github.com/bucketeer-io/android-client-sdk/issues/69
+        // Save the featureTag in the UserDefault if it is configured in the BKTConfig
+        XCTAssertEqual(
+            config.featureTag,
+            storage.featureTag,
+            "featureTag should saved if it is configured in the BKTConfig"
+        )
+        XCTAssertEqual(
+            storage.evaluatedAt,
+            "0",
+            "evaluatedAt should be `0`"
+        )
+
+        // We should have a new currentEvaluationsId now
+        XCTAssertEqual(
+            storage.currentEvaluationsId,
+            "",
+            "currentEvaluationsId should be empty string"
+        )
+        XCTAssertEqual(
+            storage.userAttributesUpdated,
+            false,
+            "userAttributesUpdated should be false"
+        )
+
         interactor.fetch(user: .mock1) { result in
             switch result {
             case .success(let response):
@@ -46,43 +95,45 @@ final class EvaluationInteractorTests: XCTestCase {
             }
 
             XCTAssertEqual(interactor.currentEvaluationsId, baseUserEvaluationsId)
-            XCTAssertEqual(interactor.evaluations[User.mock1.id], [.mock1, .mock2])
+            XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: Evaluation.mock1.featureId), .mock1)
+            XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: Evaluation.mock2.featureId), .mock2)
 
-            let evaluation = interactor.getLatest(
-                userId: User.mock1.id,
-                featureId: "feature1"
-            )
-            XCTAssertEqual(evaluation, .mock1)
-
-            expectation.fulfill()
+            testFetchInitialLoadExpectation.fulfill()
         }
+        XCTAssertEqual(
+            config.featureTag,
+            storage.featureTag,
+            "featureTag should saved if it is configured in the BKTConfig"
+        )
+        XCTAssertEqual(
+            storage.evaluatedAt,
+            evaluationCreatedAt,
+            // https://github.com/bucketeer-io/android-client-sdk/issues/69
+            "evaluatedAt the last time the user was evaluated. The server will return in the get_evaluations response (UserEvaluations.CreatedAt), and it must be saved in the client"
+        )
+        XCTAssertEqual(
+            storage.currentEvaluationsId,
+            baseUserEvaluationsId,
+            "currentEvaluationsId should not be a empty string after fetch evaluation success"
+        )
+        XCTAssertEqual(
+            storage.userAttributesUpdated,
+            false,
+            "userAttributesUpdated should be false"
+        )
 
-        wait(for: [expectation], timeout: 1)
+        wait(for: [testFetchInitialLoadExpectation], timeout: 1)
     }
 
-    func testFetchUpdate() {
+    func testFetchAndUpdate() {
         let expectation = XCTestExpectation()
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 7
         expectation.assertForOverFulfill = true
-
-        let updatedEvaluation = Evaluation(
-            id: "evaluation1_updated",
-            featureId: "feature1",
-            featureVersion: 1,
-            userId: User.mock1.id,
-            variationId: "variation1",
-            variationName: "variation name1",
-            variationValue: "variation_value1_updated",
-            reason: .init(
-                type: .rule,
-                ruleId: "rule1"
-            )
-        )
         let baseUserEvaluationsId = UserEvaluations.mock1.id
         let baseUserEvaluationsId_updated = baseUserEvaluationsId + "_updated"
         let api = MockApiClient(
-            getEvaluationsHandler: { user, userEvaluationsId, _, completion in
-
+            getEvaluationsHandler: { user, userEvaluationsId, _, _, completion in
+                expectation.fulfill()
                 XCTAssertEqual(user, .mock1)
                 if userEvaluationsId == "" {
                     // initial request
@@ -94,35 +145,61 @@ final class EvaluationInteractorTests: XCTestCase {
                 } else {
                     // second request
                     var userEvaluations = UserEvaluations.mock1
-                    userEvaluations.evaluations = [updatedEvaluation, .mock2]
+                    userEvaluations.evaluations = [.mock1Updated, .mock2]
                     userEvaluations.id = baseUserEvaluationsId_updated
                     let response = GetEvaluationsResponse(
-                        evaluations: userEvaluations,
+                        evaluations: .mock1Upsert,
                         userEvaluationsId: baseUserEvaluationsId_updated
                     )
                     completion?(.success(response))
                 }
-
-                expectation.fulfill()
             }
         )
 
-        let dao = MockEvaluationDao()
-        let defaults = MockDefaults()
+        var updateHandlerCount = 0
+        let storage = MockEvaluationStorage(updateHandler: { evaluations, archivedFeatureIds, evaluatedAt in
+            if (updateHandlerCount == 0) {
+                XCTAssertEqual(evaluations, [.mock1, .mock2])
+                XCTAssertEqual(archivedFeatureIds, [])
+                XCTAssertEqual(evaluatedAt, UserEvaluations.mock1.createdAt)
+            } else if (updateHandlerCount == 1) {
+                XCTAssertEqual(evaluations, [.mock1Updated, .mock2])
+                XCTAssertEqual(archivedFeatureIds, [])
+                XCTAssertEqual(evaluatedAt, UserEvaluations.mock1Upsert.createdAt)
+            } else {
+                XCTFail("should not call")
+            }
+            updateHandlerCount+=1
+            expectation.fulfill()
+            return true
+        }, deleteAllAndInsertHandler: { _, _ in
+            XCTFail("`deleteAllAndInsertHandler` should not called ")
+        }, getByFeatureIdHandler: { _, featureId in
+            expectation.fulfill()
+            // Mock logic to check after 2 fetch evaluation request
+            // Expectation is it should return the updated evaluation
+            if featureId == Evaluation.mock1.featureId {
+                // Should return .mock1Updated as mock1 has updated
+                return .mock1Updated
+            }
+            if featureId == Evaluation.mock2.featureId {
+                // Didn't changes
+                return .mock2
+            }
+            return nil
+        })
 
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
         XCTAssertEqual(interactor.currentEvaluationsId, "")
         // 1st
         interactor.fetch(user: .mock1) { _ in
-
             // 2nd
             interactor.fetch(user: .mock1) { result in
                 switch result {
@@ -133,13 +210,14 @@ final class EvaluationInteractorTests: XCTestCase {
                 }
 
                 XCTAssertEqual(interactor.currentEvaluationsId, baseUserEvaluationsId_updated)
-                XCTAssertEqual(interactor.evaluations[User.mock1.id], [updatedEvaluation, .mock2])
-
-                let evaluation = interactor.getLatest(
+                XCTAssertEqual(interactor.getLatest(
                     userId: User.mock1.id,
                     featureId: "feature1"
-                )
-                XCTAssertEqual(evaluation, updatedEvaluation)
+                ), .mock1Updated)
+                XCTAssertEqual(interactor.getLatest(
+                    userId: User.mock1.id,
+                    featureId: "feature2"
+                ), Evaluation.mock2)
 
                 expectation.fulfill()
             }
@@ -149,13 +227,12 @@ final class EvaluationInteractorTests: XCTestCase {
 
     func testFetchNoUpdate() {
         let expectation = XCTestExpectation()
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 6
         expectation.assertForOverFulfill = true
 
         let baseUserEvaluationsId = UserEvaluations.mock1.id
         let api = MockApiClient(
-            getEvaluationsHandler: { user, _, _, completion in
-
+            getEvaluationsHandler: { user, _, _, _, completion in
                 XCTAssertEqual(user, .mock1)
                 let response = GetEvaluationsResponse(
                     evaluations: .mock1,
@@ -166,15 +243,35 @@ final class EvaluationInteractorTests: XCTestCase {
             }
         )
 
-        let dao = MockEvaluationDao()
-        let defaults = MockDefaults()
+        let storage = MockEvaluationStorage(updateHandler: { evaluations, archivedFeatureIds, evaluatedAt in
+            XCTAssertEqual(evaluations, [.mock1, .mock2])
+            XCTAssertEqual(archivedFeatureIds, [])
+            XCTAssertEqual(evaluatedAt, UserEvaluations.mock1.createdAt)
+            expectation.fulfill()
+            return true
+        }, deleteAllAndInsertHandler: { _, _ in
+            XCTFail("`deleteAllAndInsertHandler` should not called ")
+        }, getByFeatureIdHandler: { _, featureId in
+            expectation.fulfill()
+            // Mock logic to check after 2 fetch evaluation request
+            // Expectation is it should return the updated evaluation
+            if featureId == Evaluation.mock1.featureId {
+                // Should return .mock1Updated as mock1 has updated
+                return .mock1
+            }
+            if featureId == Evaluation.mock2.featureId {
+                // Didn't changes
+                return .mock2
+            }
+            return nil
+        })
+
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
@@ -192,14 +289,14 @@ final class EvaluationInteractorTests: XCTestCase {
                 }
 
                 XCTAssertEqual(interactor.currentEvaluationsId, baseUserEvaluationsId)
-                XCTAssertEqual(interactor.evaluations[User.mock1.id], [.mock1, .mock2])
-
-                let evaluation = interactor.getLatest(
+                XCTAssertEqual(interactor.getLatest(
                     userId: User.mock1.id,
                     featureId: "feature1"
-                )
-                XCTAssertEqual(evaluation, .mock1)
-
+                ), .mock1)
+                XCTAssertEqual(interactor.getLatest(
+                    userId: User.mock1.id,
+                    featureId: "feature2"
+                ), Evaluation.mock2)
                 expectation.fulfill()
             }
         }
@@ -208,14 +305,15 @@ final class EvaluationInteractorTests: XCTestCase {
 
     func testFetchAndFailWithDBError() {
         let expectation = XCTestExpectation()
-
+        expectation.expectedFulfillmentCount = 2
+        expectation.assertForOverFulfill = true
         let baseUserEvaluationsId = UserEvaluations.mock1.id
         let api = MockApiClient(
-            getEvaluationsHandler: { user, _, _, completion in
+            getEvaluationsHandler: { user, _, _, _, completion in
 
                 XCTAssertEqual(user, .mock1)
                 let response = GetEvaluationsResponse(
-                    evaluations: .mock1,
+                    evaluations: .mock1ForceUpdate,
                     userEvaluationsId: baseUserEvaluationsId
                 )
                 completion?(.success(response))
@@ -223,17 +321,16 @@ final class EvaluationInteractorTests: XCTestCase {
             }
         )
 
-        let dao = MockEvaluationDao(deleteAllAndInsertHandler: { _, _ in
+        let storage = MockEvaluationStorage(deleteAllAndInsertHandler: { _, _ in
             throw NSError(domain: "db", code: 100, userInfo: [:])
         })
-        let defaults = MockDefaults()
+
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
@@ -252,122 +349,343 @@ final class EvaluationInteractorTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
 
-    func testRefreshCache() throws {
-        let api = MockApiClient()
-
-        let userId1 = User.mock1.id
-        let userId2 = User.mock2.id
-
-        let dao = MockEvaluationDao(getHandler: { userId in
-            switch userId {
-            case userId1:
-                return [.mock1, .mock2]
-            case userId2:
-                return [.mock3]
-            default:
-                return []
-            }
-        })
-        let defaults = MockDefaults()
-        let idGenerator = MockIdGenerator(identifier: "")
-        let config = BKTConfig.mock1
-
-        let interactor = EvaluationInteractorImpl(
-            apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
-            idGenerator: idGenerator,
-            featureTag: config.featureTag
-        )
-
-        XCTAssertEqual(interactor.evaluations[userId1], nil)
-        XCTAssertEqual(interactor.evaluations[userId2], nil)
-
-        try interactor.refreshCache(userId: userId1)
-        XCTAssertEqual(interactor.evaluations[userId1], [.mock1, .mock2])
-
-        try interactor.refreshCache(userId: userId2)
-        XCTAssertEqual(interactor.evaluations[userId2], [.mock3])
-    }
-
     func testGetLatestWithCache() throws {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 5
+        expectation.assertForOverFulfill = true
         let api = MockApiClient()
 
         let userId1 = User.mock1.id
         let userId2 = User.mock2.id
 
-        let dao = MockEvaluationDao(getHandler: { userId in
+        let storage = MockEvaluationStorage(getByFeatureIdHandler: { (userId, featureId) in
             switch userId {
             case userId1:
-                return [.mock1, .mock2]
+                expectation.fulfill()
+                if (featureId == "feature1") {
+                    return .mock1
+                }
+                if (featureId == "feature2") {
+                    return .mock2
+                }
+                return nil
             case userId2:
-                return [.mock3]
+                expectation.fulfill()
+                if (featureId == "feature3") {
+                    return .mock3
+                }
+                return nil
             default:
-                return []
+                return nil
             }
+        }, refreshCacheHandler: {
+            // 2 times
+            expectation.fulfill()
         })
-        let defaults = MockDefaults()
+
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
 
-        try interactor.refreshCache(userId: userId1)
+        try interactor.refreshCache()
+        XCTAssertEqual(interactor.getLatest(userId: userId1, featureId: "feature1"), .mock1)
+        XCTAssertEqual(interactor.getLatest(userId: userId1, featureId: "feature2"), .mock2)
 
-        XCTAssertEqual(interactor.getLatest(userId: userId1, featureId: Evaluation.mock1.featureId), .mock1)
+        try interactor.refreshCache()
+        XCTAssertEqual(interactor.getLatest(userId: userId2, featureId: "feature3"), .mock3)
+
+        wait(for: [expectation], timeout: 1)
     }
 
     func testGetLatestWithoutCache() {
         let api = MockApiClient()
-
-        let dao = MockEvaluationDao(getHandler: { _ in
-            return []
-        })
-        let defaults = MockDefaults()
+        let storage = MockEvaluationStorage()
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
-
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
-
         XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: Evaluation.mock1.featureId), nil)
     }
 
     func testGetLatestWithoutCorrespondingEvaluation() {
         let api = MockApiClient()
-
-        let dao = MockEvaluationDao(getHandler: { userId in
+        let storage = MockEvaluationStorage(getByFeatureIdHandler: { (userId, featureId) in
             switch userId {
             case User.mock1.id:
-                return [.mock1, .mock2]
+                if (featureId == "feature1") {
+                    return .mock1
+                }
+                if (featureId == "feature2") {
+                    return .mock2
+                }
+                return nil
             default:
-                return []
+                return nil
             }
         })
-        let defaults = MockDefaults()
+        let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
+        let interactor = EvaluationInteractorImpl(
+            apiClient: api,
+            evaluationStorage: storage,
+            idGenerator: idGenerator,
+            featureTag: config.featureTag
+        )
+        XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: "invalid_feature_id"), nil)
+    }
+
+    func testSetEvaluationConditionWhenRequest() {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 2
+        expectation.assertForOverFulfill = true
+
+        let baseUserEvaluationsId = UserEvaluations.mock1.id
+        let evaluationCreatedAt = UserEvaluations.mock1.createdAt
+        let storage = MockEvaluationStorage(
+            updateHandler: { _, _, _ in
+                XCTFail("we should not have any update() call")
+                return false
+            },
+            deleteAllAndInsertHandler: { _, _ in
+                XCTFail("we should not have any delete() call")
+            })
+        let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
+        // Prefill state
+        storage.currentEvaluationsId =  baseUserEvaluationsId
+        storage.featureTag =  config.featureTag
+        storage.evaluatedAt = evaluationCreatedAt
+        storage.userAttributesUpdated = false
+        XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
+        XCTAssertEqual(storage.userAttributesUpdated, false)
+        let api = MockApiClient(
+            getEvaluationsHandler: { user, userEvaluationsId, _, condition, completion in
+                XCTAssertEqual(user, .mock1)
+                XCTAssertEqual(userEvaluationsId, baseUserEvaluationsId)
+                XCTAssertEqual(condition.evaluatedAt, evaluationCreatedAt, "evaluationCreatedAt should equal the last evaluatedAt value")
+                XCTAssertEqual(condition.userAttributesUpdated, true, "userAttributesUpdated should be true")
+                let response = GetEvaluationsResponse(
+                    evaluations: .mock1,
+                    userEvaluationsId: baseUserEvaluationsId
+                )
+                completion?(.success(response))
+                expectation.fulfill()
+            }
+        )
+
+        let interactor = EvaluationInteractorImpl(
+            apiClient: api,
+            evaluationStorage: storage,
+            idGenerator: idGenerator,
+            featureTag: config.featureTag
+        )
+        XCTAssertEqual(interactor.currentEvaluationsId, baseUserEvaluationsId)
+        XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
+        XCTAssertEqual(storage.userAttributesUpdated, false)
+
+        interactor.setUserAttributesUpdated()
+        XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
+        XCTAssertEqual(storage.userAttributesUpdated, true)
+
+        interactor.fetch(user: .mock1) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.userEvaluationsId, UserEvaluations.mock1.id)
+            case .failure(let error, _):
+                XCTFail("\(error)")
+            }
+            expectation.fulfill()
+        }
+
+        // post checking
+        XCTAssertEqual(storage.currentEvaluationsId, UserEvaluations.mock1.id)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1.createdAt)
+        // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
+        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+
+        wait(for: [expectation], timeout: 1)
+    }
+
+    func testChangeFeatureTagWillClearUserEvaluationsId() {
+        let baseUserEvaluationsId = UserEvaluations.mock1.id
+        let api = MockApiClient()
+        let storage = MockEvaluationStorage()
+
+        // Prefill state
+        storage.currentEvaluationsId = "id_should_be_replaced"
+        storage.featureTag =  "feature_tag_should_be_replaced"
+
+        let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
+
+        XCTAssertEqual(storage.currentEvaluationsId, "id_should_be_replaced")
+        XCTAssertEqual(storage.featureTag, "feature_tag_should_be_replaced")
+
+        let interactor = EvaluationInteractorImpl(
+            apiClient: api,
+            evaluationStorage: storage,
+            idGenerator: idGenerator,
+            featureTag: config.featureTag
+        )
+        XCTAssertEqual(interactor.currentEvaluationsId, "")
+        XCTAssertEqual(storage.currentEvaluationsId, "")
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+    }
+
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // Delete all the evaluations from DB, and save the latest evaluations from the response into the DB
+    func testForceUpdateEvaluations() {
+        let expectation = XCTestExpectation(description: "testForceUpdateEvaluations")
+        expectation.expectedFulfillmentCount = 3
+        expectation.assertForOverFulfill = true
+
+        let baseUserEvaluationsId = UserEvaluations.mock1.id
+        let api = MockApiClient(
+            getEvaluationsHandler: { user, userEvaluationsId, _, condition, completion in
+                XCTAssertEqual(user, .mock1)
+                XCTAssertEqual(userEvaluationsId, "")
+                XCTAssertEqual(condition.evaluatedAt, "0", "evaluationCreatedAt should equal the last evaluatedAt value")
+                XCTAssertEqual(condition.userAttributesUpdated, true, "userAttributesUpdated should be true")
+
+                let response = GetEvaluationsResponse(
+                    evaluations: .mock1ForceUpdate,
+                    userEvaluationsId: baseUserEvaluationsId
+                )
+                completion?(.success(response))
+                expectation.fulfill()
+            }
+        )
+        let storage = MockEvaluationStorage(
+            updateHandler: { _, _, _ in
+                XCTFail("we should not have any update() call")
+                return false
+            },
+            deleteAllAndInsertHandler: { userId, evaluations in
+                XCTAssertEqual(User.mock1.id, userId)
+                XCTAssertEqual(evaluations, UserEvaluations.mock1ForceUpdate.evaluations)
+                expectation.fulfill()
+            })
+
         let idGenerator = MockIdGenerator(identifier: "")
         let config = BKTConfig.mock1
 
         let interactor = EvaluationInteractorImpl(
             apiClient: api,
-            evaluationDao: dao,
-            defaults: defaults,
+            evaluationStorage: storage,
             idGenerator: idGenerator,
             featureTag: config.featureTag
         )
 
-        XCTAssertEqual(interactor.getLatest(userId: User.mock1.id, featureId: "invalid_feature_id"), nil)
+        // set `userAttributesUpdated` == true
+        interactor.setUserAttributesUpdated()
+        interactor.fetch(user: .mock1) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.userEvaluationsId, baseUserEvaluationsId)
+                XCTAssertEqual(response.evaluations, .mock1ForceUpdate)
+                XCTAssertEqual(response.evaluations.forceUpdate, true)
+                XCTAssertEqual(response.evaluations.archivedFeatureIds, [])
+            case .failure(let error, _):
+                XCTFail("\(error)")
+            }
+            expectation.fulfill()
+        }
+
+        // post checking
+        XCTAssertEqual(storage.currentEvaluationsId, UserEvaluations.mock1ForceUpdate.id)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1ForceUpdate.createdAt)
+        // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
+        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    // https://github.com/bucketeer-io/android-client-sdk/issues/69
+    // Check the evaluation list in the response and upsert them in the DB if the list is not empty
+    // Check the list of the feature flags that were archived on the console and delete them from the DB
+    func testUpsertEvaluations() {
+        let expectation = XCTestExpectation(description: "testForceUpdateEvaluations")
+        expectation.expectedFulfillmentCount = 3
+        expectation.assertForOverFulfill = true
+
+        let baseUserEvaluationsId = UserEvaluations.mock1.id
+        let api = MockApiClient(
+            getEvaluationsHandler: { user, userEvaluationsId, _, condition, completion in
+                XCTAssertEqual(user, .mock1)
+                XCTAssertEqual(userEvaluationsId, "")
+                XCTAssertEqual(condition.evaluatedAt, "0", "evaluationCreatedAt should equal the last evaluatedAt value")
+                XCTAssertEqual(condition.userAttributesUpdated, true, "userAttributesUpdated should be true")
+
+                let response = GetEvaluationsResponse(
+                    evaluations: .mock1UpsertAndArchivedFeature,
+                    userEvaluationsId: baseUserEvaluationsId
+                )
+                completion?(.success(response))
+                expectation.fulfill()
+            }
+        )
+        let storage = MockEvaluationStorage(updateHandler: { evaluations, archivedFeatureIds, evaluatedAt  in
+            XCTAssertEqual(evaluations, UserEvaluations.mock1UpsertAndArchivedFeature.evaluations)
+            XCTAssertEqual(evaluatedAt, UserEvaluations.mock1UpsertAndArchivedFeature.createdAt)
+            XCTAssertEqual(archivedFeatureIds, UserEvaluations.mock1UpsertAndArchivedFeature.archivedFeatureIds)
+            expectation.fulfill()
+            return true
+        }, deleteAllAndInsertHandler: { _, _ in
+            XCTFail("we should not have any deleteAllHandler() call")
+        })
+
+        let idGenerator = MockIdGenerator(identifier: "")
+        let config = BKTConfig.mock1
+
+        let interactor = EvaluationInteractorImpl(
+            apiClient: api,
+            evaluationStorage: storage,
+            idGenerator: idGenerator,
+            featureTag: config.featureTag
+        )
+
+        // set `userAttributesUpdated` == true
+        interactor.setUserAttributesUpdated()
+        interactor.fetch(user: .mock1) { result in
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.evaluations.forceUpdate, false)
+                XCTAssertEqual(response.evaluations.evaluations, UserEvaluations.mock1UpsertAndArchivedFeature.evaluations)
+                XCTAssertEqual(response.evaluations.createdAt, UserEvaluations.mock1UpsertAndArchivedFeature.createdAt)
+                XCTAssertEqual(response.evaluations.archivedFeatureIds, UserEvaluations.mock1UpsertAndArchivedFeature.archivedFeatureIds)
+            case .failure(let error, _):
+                XCTFail("\(error)")
+            }
+            expectation.fulfill()
+        }
+
+        // post checking
+        XCTAssertEqual(storage.currentEvaluationsId, UserEvaluations.mock1UpsertAndArchivedFeature.id)
+        XCTAssertEqual(storage.featureTag, config.featureTag)
+        XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1UpsertAndArchivedFeature.createdAt)
+        // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
+        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+
+        wait(for: [expectation], timeout: 0.1)
     }
 }
-// swiftlint:enable type_body_length
+
+// swiftlint:enable type_body_length file_length

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -1,0 +1,200 @@
+import XCTest
+@testable import Bucketeer
+
+@available(iOS 13, *)
+final class EvaluationStorageTests: XCTestCase {
+    func testGetByUserId() throws {
+        let expectation = XCTestExpectation(description: "testGetByUserId")
+        expectation.expectedFulfillmentCount = 1
+        expectation.assertForOverFulfill = true
+        let testUserId1 = Evaluation.mock1.userId
+        let mockDao = MockEvaluationDao(getHandler: { userId in
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            if userId == testUserId1 {
+                return [ .mock1, .mock2]
+            }
+            return []
+        })
+        let mockUserDefsDao = MockEvaluationUserDefaultsDao()
+        let cacheDao = EvaluationMemCacheDao()
+        let storage = EvaluationStorageImpl(
+            userId: testUserId1,
+            evaluationDao: mockDao,
+            evaluationMemCacheDao: cacheDao,
+            evaluationUserDefaultsDao: mockUserDefsDao
+        )
+        // Check cache
+        let expected : [Evaluation] = [.mock1, .mock2]
+        XCTAssertEqual(expected, cacheDao.get(key: testUserId1))
+        XCTAssertEqual(expected, try? storage.get(userId: testUserId1))
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testGetByUserIdAndFeatureId() throws {
+        let expectation = XCTestExpectation(description: "testGetByUserId")
+        expectation.expectedFulfillmentCount = 1
+        expectation.assertForOverFulfill = true
+        let testUserId1 = Evaluation.mock1.userId
+        let mockDao = MockEvaluationDao(getHandler: { userId in
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            if userId == testUserId1 {
+                return [ .mock1, .mock2]
+            }
+            return []
+        })
+        let mockUserDefsDao = MockEvaluationUserDefaultsDao()
+        let storage = EvaluationStorageImpl(
+            userId: testUserId1,
+            evaluationDao: mockDao,
+            evaluationMemCacheDao: EvaluationMemCacheDao(),
+            evaluationUserDefaultsDao: mockUserDefsDao
+        )
+        // Should return first evaluation has `feature_id` == Evaluation.mock2.featureId
+        let expected = storage.getBy(userId: testUserId1, featureId: Evaluation.mock2.featureId)
+        XCTAssertEqual(expected, .mock2)
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testDeleteAllAndInsert() throws {
+        let expectation = XCTestExpectation(description: "testGetByUserId")
+        expectation.expectedFulfillmentCount = 4
+        expectation.assertForOverFulfill = true
+        let testUserId1 = Evaluation.mock1.userId
+        let mockDao = MockEvaluationDao(putHandler: { userId, evaluations in
+            // 2. put new data
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            XCTAssertEqual(evaluations, [.mock1, .mock2])
+        }, getHandler: { userId in
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            if userId == testUserId1 {
+                return [ .mock1, .mock2]
+            }
+            return []
+        }, deleteAllHandler: { userId in
+            // 1. delete all
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+        }, deleteByIdsHandlder: { _ in
+            XCTFail("should not called")
+        }, startTransactionHandler: { block in
+            // Should use use transaction
+            try block()
+            expectation.fulfill()
+        })
+        let mockUserDefsDao = MockEvaluationUserDefaultsDao()
+        let storage = EvaluationStorageImpl(
+            userId: testUserId1,
+            evaluationDao: mockDao,
+            evaluationMemCacheDao: EvaluationMemCacheDao(),
+            evaluationUserDefaultsDao: mockUserDefsDao
+        )
+        try storage.deleteAllAndInsert(userId: testUserId1, evaluations: [.mock1, .mock2], evaluatedAt: "1024")
+        let expected = try storage.get(userId: testUserId1)
+        XCTAssertEqual(expected, [.mock1, .mock2])
+        XCTAssertEqual(storage.evaluatedAt, "1024", "should save last evaluatedAt")
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testUpdate() throws {
+        let expectation = XCTestExpectation(description: "testGetByUserId")
+        expectation.expectedFulfillmentCount = 5
+        expectation.assertForOverFulfill = true
+        let testUserId1 = Evaluation.mock1.userId
+        let mock2Updated = Evaluation(
+            id: "evaluation2",
+            featureId: "feature2",
+            featureVersion: 1,
+            userId: User.mock1.id,
+            variationId: "variation2_updated",
+            variationName: "variation name2 updated",
+            variationValue: "2",
+            reason: .init(
+                type: .rule,
+                ruleId: "rule2"
+            )
+        )
+        var getHandlerAccessCount = 0
+        let mockDao = MockEvaluationDao(putHandler: { userId, evaluations in
+            // Should update .mock2Updated
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            XCTAssertEqual(evaluations, [mock2Updated])
+        }, getHandler: { userId in
+            // Should fullfill 2 times
+            // 1 for init cache
+            // 2 for prepare for update by loading the valid data from database
+            expectation.fulfill()
+            XCTAssertEqual(testUserId1, userId)
+            getHandlerAccessCount+=1
+            switch getHandlerAccessCount {
+            case 1 :
+                if userId == testUserId1 {
+                    // From the first time in the database has 2 items
+                    return [ .mock1, .mock2]
+                }
+            case 2 :
+                if userId == testUserId1 {
+                    // .mock2 get some update
+                    return [.mock1, mock2Updated]
+                }
+            // Finally, we should expected only mock2updated in the database
+            default: return [mock2Updated]
+            }
+            return []
+        }, deleteAllHandler: { _ in
+            XCTFail("should not called")
+        }, deleteByIdsHandlder: { ids in
+            // Should delete .mock1
+            expectation.fulfill()
+            XCTAssertEqual(ids, [Evaluation.mock1.id])
+        }, startTransactionHandler: { block in
+            // Should use use transaction
+            try block()
+            expectation.fulfill()
+        })
+        let mockUserDefsDao = MockEvaluationUserDefaultsDao()
+        let storage = EvaluationStorageImpl(
+            userId: testUserId1,
+            evaluationDao: mockDao,
+            evaluationMemCacheDao: EvaluationMemCacheDao(),
+            evaluationUserDefaultsDao: mockUserDefsDao
+        )
+        // Should update Evaluation.mock2 & remove Evaluation.mock1
+        let result = try storage.update(evaluations: [mock2Updated], archivedFeatureIds: [Evaluation.mock1.featureId], evaluatedAt: "1024")
+        XCTAssertTrue(result, "update action should success")
+        XCTAssertEqual(storage.evaluatedAt, "1024", "should save last evaluatedAt")
+        XCTAssertEqual(try storage.get(userId: testUserId1), [mock2Updated], "Finally, we should expected only mock2updated in the database")
+        wait(for: [expectation], timeout: 0.1)
+    }
+
+    func testGetStorageValues() throws {
+        let testUserId1 = Evaluation.mock1.userId
+        let mockDao = MockEvaluationDao()
+        let mockUserDefsDao = MockEvaluationUserDefaultsDao()
+        let storage = EvaluationStorageImpl(
+            userId: testUserId1,
+            evaluationDao: mockDao,
+            evaluationMemCacheDao: EvaluationMemCacheDao(),
+            evaluationUserDefaultsDao: mockUserDefsDao
+        )
+
+        XCTAssertEqual(storage.evaluatedAt, "0", "should = 0")
+        XCTAssertEqual(storage.currentEvaluationsId, "")
+        XCTAssertFalse(storage.userAttributesUpdated)
+        XCTAssertEqual(storage.featureTag, "")
+
+        storage.currentEvaluationsId = "evaluationIdForTest"
+        storage.userAttributesUpdated = true
+        storage.featureTag = "featureTagForTest"
+        let result = try storage.update(evaluations: [.mock2], archivedFeatureIds: [Evaluation.mock1.featureId], evaluatedAt: "1024")
+        XCTAssertTrue(result, "update action should success")
+        XCTAssertEqual(storage.evaluatedAt, "1024", "should save last evaluatedAt")
+        XCTAssertEqual(storage.currentEvaluationsId, "evaluationIdForTest")
+        XCTAssertTrue(storage.userAttributesUpdated)
+        XCTAssertEqual(storage.featureTag, "featureTagForTest")
+    }
+}

--- a/BucketeerTests/EvaluationUserDefaultDaoTest.swift
+++ b/BucketeerTests/EvaluationUserDefaultDaoTest.swift
@@ -1,0 +1,23 @@
+import XCTest
+@testable import Bucketeer
+
+final class EvaluationUserDefaultDaoTests: XCTestCase {
+
+    func testGetSet() {
+        let defaults = MockDefaults()
+        let userEvalutionStorage = EvaluationUserDefaultDaoImpl(defaults: defaults)
+        XCTAssertEqual(userEvalutionStorage.currentEvaluationsId, "")
+        XCTAssertEqual(userEvalutionStorage.featureTag, "")
+        XCTAssertEqual(userEvalutionStorage.evaluatedAt, "0", "evaluatedAt should be `0` if it didn't save before")
+        XCTAssertEqual(userEvalutionStorage.userAttributesUpdated, false)
+        // Prefill state
+        userEvalutionStorage.currentEvaluationsId = "1"
+        userEvalutionStorage.featureTag = "tag"
+        userEvalutionStorage.evaluatedAt = "22334455"
+        userEvalutionStorage.userAttributesUpdated = true
+        XCTAssertEqual(userEvalutionStorage.currentEvaluationsId, "1")
+        XCTAssertEqual(userEvalutionStorage.featureTag, "tag")
+        XCTAssertEqual(userEvalutionStorage.evaluatedAt, "22334455")
+        XCTAssertEqual(userEvalutionStorage.userAttributesUpdated, true)
+    }
+}

--- a/BucketeerTests/InMemoryCacheTests.swift
+++ b/BucketeerTests/InMemoryCacheTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import Bucketeer
+
+final class InMemoryCacheTests: XCTestCase {
+
+    func testGetSet() throws {
+        let memCache = InMemoryCache<String>()
+        // Prefill state
+        memCache.set(key: "key", value: "value")
+        memCache.set(key: "key", value: "value2")
+        memCache.set(key: "key1", value: "value1")
+
+        XCTAssertEqual(memCache.get(key: "key"), "value2")
+        XCTAssertEqual(memCache.get(key: "key1"), "value1")
+    }
+}

--- a/BucketeerTests/Mock/MockBKTConfig.swift
+++ b/BucketeerTests/Mock/MockBKTConfig.swift
@@ -8,13 +8,14 @@ extension BKTConfig {
         eventsFlushInterval: Int64 = Constant.DEFAULT_FLUSH_INTERVAL_MILLIS,
         eventsMaxQueueSize: Int = Constant.DEFAULT_MAX_QUEUE_SIZE,
         pollingInterval: Int64 = Constant.DEFAULT_POLLING_INTERVAL_MILLIS,
-        backgroundPollingInterval: Int64 = Constant.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS) -> BKTConfig {
+        backgroundPollingInterval: Int64 = Constant.DEFAULT_BACKGROUND_POLLING_INTERVAL_MILLIS,
+        featureTag: String = "featureTag1") -> BKTConfig {
         // Direct init BKTConfig and bypass all validations
         // It could only happen with internal access
         return BKTConfig(
             apiKey: "api_key_value",
             apiEndpoint: URL(string: "https://test.bucketeer.io")!,
-            featureTag: "featureTag1",
+            featureTag: featureTag,
             eventsFlushInterval: eventsFlushInterval,
             eventsMaxQueueSize: eventsMaxQueueSize,
             pollingInterval: pollingInterval,

--- a/BucketeerTests/Mock/MockDataModule.swift
+++ b/BucketeerTests/Mock/MockDataModule.swift
@@ -5,10 +5,10 @@ struct MockDataModule: DataModule {
     var config: BKTConfig = .mock1
     var userHolder: UserHolder = .init(user: .mock1)
     var apiClient: ApiClient = MockApiClient(getEvaluationsHandler: nil, registerEventsHandler: nil)
-    var evaluationDao: EvaluationDao = MockEvaluationDao(putHandler: nil, getHandler: nil, deleteAllAndInsertHandler: nil)
     var eventDao: EventDao = MockEventDao(addEventsHandler: nil, getEventsHandler: nil, deleteEventsHandler: nil)
     var defaults: Defaults = MockDefaults()
     var idGenerator: IdGenerator = MockIdGenerator(identifier: "id")
     var clock: Clock = MockClock(timestamp: 1)
     var device: Device = MockDevice()
+    var evaluationStorage: EvaluationStorage = MockEvaluationStorage(updateHandler: nil, deleteAllAndInsertHandler: nil)
 }

--- a/BucketeerTests/Mock/MockDefaults.swift
+++ b/BucketeerTests/Mock/MockDefaults.swift
@@ -2,6 +2,10 @@ import Foundation
 @testable import Bucketeer
 
 final class MockDefaults: Defaults {
+    func bool(forKey defaultName: String) -> Bool {
+        return dict[defaultName] as? Bool ?? false
+    }
+
     var dict: [String: Any?] = [:]
 
     func string(forKey defaultName: String) -> String? {

--- a/BucketeerTests/Mock/MockEvaluationDao.swift
+++ b/BucketeerTests/Mock/MockEvaluationDao.swift
@@ -2,22 +2,32 @@ import Foundation
 @testable import Bucketeer
 
 final class MockEvaluationDao: EvaluationDao {
+    func startTransaction(block: () throws -> Void) throws {
+        try self.startTransactionHandler?(block)
+    }
 
     typealias PutHandler = ((String, [Evaluation]) throws -> Void)
     typealias GetHandler = (String) throws -> [Evaluation]
-    typealias DeleteAllAndInsertHandler = (String, [Evaluation]) throws -> Void
+    typealias DeleteAllHandler = (String) throws -> Void
+    typealias DeleteByIdsHandler = ([String]) throws -> Void
+    typealias StartTransactionHandler = (TransactionBlock) throws -> Void
 
     let putHandler: PutHandler?
     let getHandler: GetHandler?
-    let deleteAllAndInsertHandler: DeleteAllAndInsertHandler?
+    let deleteAllHandler: DeleteAllHandler?
+    let deleteByIdsHanlder: DeleteByIdsHandler?
+    let startTransactionHandler: StartTransactionHandler?
 
     init(putHandler: PutHandler? = nil,
          getHandler: GetHandler? = nil,
-         deleteAllAndInsertHandler: DeleteAllAndInsertHandler? = nil) {
-
+         deleteAllHandler: DeleteAllHandler? = nil,
+         deleteByIdsHandlder: DeleteByIdsHandler? = nil,
+         startTransactionHandler: StartTransactionHandler? = nil) {
         self.putHandler = putHandler
         self.getHandler = getHandler
-        self.deleteAllAndInsertHandler = deleteAllAndInsertHandler
+        self.deleteAllHandler = deleteAllHandler
+        self.deleteByIdsHanlder = deleteByIdsHandlder
+        self.startTransactionHandler = startTransactionHandler
     }
 
     func put(userId: String, evaluations: [Evaluation]) throws {
@@ -28,7 +38,11 @@ final class MockEvaluationDao: EvaluationDao {
         return try getHandler?(userId) ?? []
     }
 
-    func deleteAllAndInsert(userId: String, evaluations: [Evaluation]) throws {
-        try deleteAllAndInsertHandler?(userId, evaluations)
+    func deleteByIds(_ ids: [String]) throws {
+        try deleteByIdsHanlder?(ids)
+    }
+
+    func deleteAll(userId: String) throws {
+        try deleteAllHandler?(userId)
     }
 }

--- a/BucketeerTests/Mock/MockEvaluationInteractor.swift
+++ b/BucketeerTests/Mock/MockEvaluationInteractor.swift
@@ -2,6 +2,7 @@ import Foundation
 @testable import Bucketeer
 
 struct MockEvaluationInteractor: EvaluationInteractor {
+
     typealias FetchHandler = (_ user: User, _ timeoutMillis: Int64?, _ completion: ((GetEvaluationsResult) -> Void)?) -> Void
 
     var fetchHandler: FetchHandler?
@@ -13,17 +14,16 @@ struct MockEvaluationInteractor: EvaluationInteractor {
     func getLatest(userId: String, featureId: String) -> Evaluation? {
         fatalError()
     }
-    func refreshCache(userId: String) throws {
-    }
-    func clearCurrentEvaluationsId() {
-    }
+
+    func refreshCache() throws {}
+
+    func setUserAttributesUpdated() {}
+
     func addUpdateListener(listener: Bucketeer.EvaluationUpdateListener) -> String {
         return ""
     }
 
-    func removeUpdateListener(key: String) {
-    }
+    func removeUpdateListener(key: String) {}
 
-    func clearUpdateListeners() {
-    }
+    func clearUpdateListeners() {}
 }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -1,0 +1,107 @@
+import Foundation
+@testable import Bucketeer
+
+final class MockEvaluationStorage: EvaluationStorage {
+    var currentEvaluationsId: String {
+        get {
+            return evaluationUserDefaultsDao.currentEvaluationsId
+        }
+        set {
+            evaluationUserDefaultsDao.currentEvaluationsId = newValue
+        }
+    }
+
+    var featureTag: String {
+        get {
+            return evaluationUserDefaultsDao.featureTag
+        }
+        set {
+            evaluationUserDefaultsDao.featureTag = newValue
+        }
+    }
+
+    var evaluatedAt: String {
+        get {
+            return evaluationUserDefaultsDao.evaluatedAt
+        }
+        set {
+            evaluationUserDefaultsDao.evaluatedAt = newValue
+        }
+    }
+
+    var userAttributesUpdated: Bool {
+        get {
+            return evaluationUserDefaultsDao.userAttributesUpdated
+        }
+        set {
+            evaluationUserDefaultsDao.userAttributesUpdated = newValue
+        }
+    }
+
+    typealias PutHandler = ((String, [Evaluation]) throws -> Void)
+    typealias GetHandler = (String) throws -> [Evaluation]
+    typealias DeleteAllAndInsertHandler = (String, [Evaluation]) throws -> Void
+    typealias UpdateHandler = ([Evaluation], [String], String) throws -> Bool
+    typealias GetByFeatureIdHandler = (String, String) -> Evaluation?
+    typealias RefreshCacheHandler = () -> Void
+
+    let getHandler: GetHandler?
+    let updateHandler: UpdateHandler?
+    let deleteAllAndInsertHandler: DeleteAllAndInsertHandler?
+    let getByFeatureIdHandler: GetByFeatureIdHandler?
+    let evaluationUserDefaultsDao = MockEvaluationUserDefaultsDao()
+    let refreshCacheHandler: RefreshCacheHandler?
+
+    init(getHandler: GetHandler? = nil,
+         updateHandler: UpdateHandler? = nil,
+         deleteAllAndInsertHandler: DeleteAllAndInsertHandler? = nil,
+         getByFeatureIdHandler: GetByFeatureIdHandler? = nil,
+         refreshCacheHandler: RefreshCacheHandler? = nil) {
+        self.getHandler = getHandler
+        self.deleteAllAndInsertHandler = deleteAllAndInsertHandler
+        self.updateHandler = updateHandler
+        self.getByFeatureIdHandler = getByFeatureIdHandler
+        self.refreshCacheHandler = refreshCacheHandler
+    }
+
+    func get(userId: String) throws -> [Evaluation] {
+        return try getHandler?(userId) ?? []
+    }
+
+    func deleteAllAndInsert(userId: String, evaluations: [Bucketeer.Evaluation], evaluatedAt: String) throws {
+        try deleteAllAndInsertHandler?(userId, evaluations)
+        // Mock save evaluatedAt
+        evaluationUserDefaultsDao.evaluatedAt = evaluatedAt
+    }
+
+    func update(evaluations: [Evaluation], archivedFeatureIds: [String], evaluatedAt: String) throws -> Bool {
+        let result = try updateHandler?(evaluations, archivedFeatureIds, evaluatedAt) ?? false
+        // Mock save evaluatedAt
+        evaluationUserDefaultsDao.evaluatedAt = evaluatedAt
+        return result
+    }
+
+    func getBy(userId: String, featureId: String) -> Evaluation? {
+        return getByFeatureIdHandler?(userId, featureId)
+    }
+
+    func refreshCache() throws {
+        refreshCacheHandler?()
+    }
+
+    func setCurrentEvaluationsId(value: String) {
+        currentEvaluationsId = value
+    }
+
+    func setFeatureTag(value: String) {
+        featureTag = value
+    }
+
+    func setEvaluatedAt(value: String) {
+        evaluatedAt = value
+    }
+
+    func setUserAttributesUpdated(value: Bool) {
+        userAttributesUpdated = value
+    }
+}

--- a/BucketeerTests/Mock/MockEvaluationUpdateListener.swift
+++ b/BucketeerTests/Mock/MockEvaluationUpdateListener.swift
@@ -1,0 +1,14 @@
+import Foundation
+@testable import Bucketeer
+
+final class MockEvaluationUpdateListener: EvaluationUpdateListener {
+    let handler: (() -> Void)?
+
+    init(handler: (() -> Void)? = nil) {
+        self.handler = handler
+    }
+
+    func onUpdate() {
+        handler?()
+    }
+}

--- a/BucketeerTests/Mock/MockEvaluationUserDefaultsDao.swift
+++ b/BucketeerTests/Mock/MockEvaluationUserDefaultsDao.swift
@@ -1,0 +1,25 @@
+import Foundation
+@testable import Bucketeer
+
+final class MockEvaluationUserDefaultsDao: EvaluationUserDefaultsDao {
+    var featureTag = ""
+    var currentEvaluationsId = ""
+    var evaluatedAt = "0"
+    var userAttributesUpdated = false
+
+    func setFeatureTag(value: String) {
+        featureTag = value
+    }
+
+    func setCurrentEvaluationsId(value: String) {
+        currentEvaluationsId = value
+    }
+
+    func setUserAttributesUpdated(value: Bool) {
+        userAttributesUpdated = value
+    }
+
+    func setEvaluatedAt(value: String) {
+        evaluatedAt = value
+    }
+}

--- a/BucketeerTests/Mock/MockEvaluations.swift
+++ b/BucketeerTests/Mock/MockEvaluations.swift
@@ -18,6 +18,20 @@ extension Evaluation {
         )
     )
 
+    static let mock1Updated = Evaluation(
+        id: "evaluation1_updated",
+        featureId: "feature1",
+        featureVersion: 1,
+        userId: User.mock1.id,
+        variationId: "variation1",
+        variationName: "variation name1",
+        variationValue: "variation_value1_updated",
+        reason: .init(
+            type: .rule,
+            ruleId: "rule1"
+        )
+    )
+
     /// id: evaluation2 - user: user1, value: int
     static let mock2 = Evaluation(
         id: "evaluation2",
@@ -82,11 +96,41 @@ extension Evaluation {
 extension UserEvaluations {
     static let mock1 = UserEvaluations(
         id: "user_evaluation1",
-        evaluations: [.mock1, .mock2]
+        evaluations: [.mock1, .mock2],
+        createdAt: "1690798000",
+        forceUpdate: false,
+        archivedFeatureIds: []
+    )
+
+    static let mock1Upsert = UserEvaluations(
+        id: "user_evaluation1",
+        evaluations: [.mock1Updated, .mock2],
+        createdAt: "1690798021",
+        forceUpdate: false,
+        archivedFeatureIds: []
+    )
+
+    static let mock1ForceUpdate = UserEvaluations(
+        id: "user_evaluation1",
+        evaluations: [.mock1, .mock2],
+        createdAt: "1690798021",
+        forceUpdate: true,
+        archivedFeatureIds: []
+    )
+
+    static let mock1UpsertAndArchivedFeature = UserEvaluations(
+        id: "user_evaluation1",
+        evaluations: [.mock1],
+        createdAt: "1690798021",
+        forceUpdate: false,
+        archivedFeatureIds: [Evaluation.mock2.featureId]
     )
 
     static let mock2 = UserEvaluations(
         id: "user_evaluation2",
-        evaluations: [.mock3, .mock4, .mock5]
+        evaluations: [.mock3, .mock4, .mock5],
+        createdAt: "",
+        forceUpdate: false,
+        archivedFeatureIds: []
     )
 }

--- a/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,92 +2,97 @@
   "images" : [
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "20x20",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "20x20"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "29x29",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "29x29"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "40x40",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "40x40"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "60x60"
     },
     {
       "idiom" : "iphone",
-      "size" : "60x60",
-      "scale" : "3x"
+      "scale" : "3x",
+      "size" : "60x60"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "20x20",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "20x20"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "29x29",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "29x29"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "40x40",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "40x40"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "1x"
+      "scale" : "1x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "76x76",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "76x76"
     },
     {
       "idiom" : "ipad",
-      "size" : "83.5x83.5",
-      "scale" : "2x"
+      "scale" : "2x",
+      "size" : "83.5x83.5"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "scale" : "1x",
+      "size" : "1024x1024"
     }
   ],
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,15 @@ BUILD_FOR_TESTING=$(XCODEBUILD) $(OPTIONS) $(DESTINATION) \
 	build-for-testing
 TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(OPTIONS) $(DESTINATION) \
 	-configuration Test \
-	-skip-testing:BucketeerTests/BucketeerE2ETests \
+	-skip-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
+	-skip-testing:BucketeerTests/E2EEvaluationTests \
+	-skip-testing:BucketeerTests/E2EEventTests \
 	test-without-building
 E2E_WITHOUT_BUILDING=$(XCODEBUILD) $(OPTIONS) $(DESTINATION) \
 	-configuration Test \
-	-only-testing:BucketeerTests/BucketeerE2ETests \
+	-only-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
+	-only-testing:BucketeerTests/E2EEvaluationTests \
+	-only-testing:BucketeerTests/E2EEventTests \
 	test-without-building E2E_API_ENDPOINT=$(E2E_API_ENDPOINT) E2E_API_KEY=$(E2E_API_KEY)
 ALL_TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(OPTIONS) $(DESTINATION) \
 	-configuration Test \


### PR DESCRIPTION
# Changes
- [x] Refactoring iOS evaluation data access layer
- [x] Using transaction for SQLite db access 
- [x] Fix all swift lint errors on the project source code
- [x] Change the featureTag setting to be optional in the BKTConfig
- [x] Save the featureTag in the `UserDefault` if it is configured in the BKTConfig
- [x] Clear the userEvaluationsID in the `UserDefault` if the featureTag changes
- [x] new fields will be added to `get_evaluations` request. (`evaluatedAt` & `userAttibutesUpdated`)
- [x] Update conditions when getting the response
  - ForceUpdate is True
     - [x]  Delete all the evaluations from DB, and save the latest evaluations from the response into the DB
     - [x] Save the UserEvaluations.CreatedAt in the response as `evaluatedAt` in the `UserDefault`
   - ForceUpdate is false
     - [x] Check the evaluation list in the response and upsert them in the DB if the list is not empty
     - [x] Check the list of the feature flags that were archived on the console and delete them from the DB
     - [x] Save the UserEvaluations.CreatedAt in the response as `evaluatedAt` in the `UserDefault`
     - [x]  Fix refresh in-memory cache logic after upsert
- [x] Update test cases
     - [x] E2E test 
     - [x] EvaluationIntergation Tests 
     - [x] EvaluationStatesStorage Tests
     - [x] EvaluationDao Tests
     - [x] BKTClient Tests
     - [x] BKTConfig Tests
     - [x]  APIClientTests
     