### PR TITLE
fix: sending duplicate events

### DIFF
--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -26,7 +26,7 @@ final class EventInteractorImpl: EventInteractor {
     let idGenerator: IdGenerator
     let logger: Logger?
     let featureTag: String
-    
+
     private let sendEventSemaphore = DispatchSemaphore(value: 1)
     private let metadata: [String: String]
     private var eventUpdateListener: EventUpdateListener?

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -703,8 +703,7 @@ final class EventInteractorTests: XCTestCase {
             }
             semaphore.signal()
             semaphore.signal()
-            semaphore.signal()
-            DispatchQueue.main.async {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
                 semaphore.signal()
                 semaphore.signal()
                 semaphore.signal()
@@ -712,7 +711,6 @@ final class EventInteractorTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-
         wait(for: [expectation], timeout: 10)
     }
 }

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -696,7 +696,7 @@ final class EventInteractorTests: XCTestCase {
             for i in 1...3 {
                 semaphore.wait()
                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.01) {
-                    count = count + i
+                    count+=i
                     print(count)
                     semaphore.signal()
                 }


### PR DESCRIPTION
### Changes 
- [x] Make sure sendEvent() run synchronized in the current queue even with its callback func

### Bug fix
- This PR should fix https://github.com/bucketeer-io/ios-client-sdk/issues/23