### PR TITLE
feat: make APIClient run synchronized

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -121,6 +121,7 @@
 		93AC8F8028E351C500A4719B /* ScheduledTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93AC8F7F28E351C500A4719B /* ScheduledTask.swift */; };
 		941E007E2A4FD964002CBFBB /* BKTConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 941E007D2A4FD964002CBFBB /* BKTConfigTests.swift */; };
 		949542E42A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949542E32A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift */; };
+		94E130F22A8DD07700120F84 /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94E130F12A8DD07700120F84 /* Logger.swift */; };
 		E2BE019D2A531C120040F40F /* BKTUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2BE019C2A531C120040F40F /* BKTUserTests.swift */; };
 		EB2310E2209D91640023A98D /* SecondViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2310E1209D91640023A98D /* SecondViewController.swift */; };
 		EB2310E4209D92570023A98D /* ThirdViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB2310E3209D92570023A98D /* ThirdViewController.swift */; };
@@ -288,6 +289,7 @@
 		93AC8F7F28E351C500A4719B /* ScheduledTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduledTask.swift; sourceTree = "<group>"; };
 		941E007D2A4FD964002CBFBB /* BKTConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTConfigTests.swift; sourceTree = "<group>"; };
 		949542E32A3AEBC0008D0C60 /* MetricsEventUniqueKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetricsEventUniqueKeyTests.swift; sourceTree = "<group>"; };
+		94E130F12A8DD07700120F84 /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
 		E2BE019C2A531C120040F40F /* BKTUserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTUserTests.swift; sourceTree = "<group>"; };
 		EB2310E1209D91640023A98D /* SecondViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecondViewController.swift; sourceTree = "<group>"; };
 		EB2310E3209D92570023A98D /* ThirdViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThirdViewController.swift; sourceTree = "<group>"; };
@@ -681,6 +683,7 @@
 				EB2310E1209D91640023A98D /* SecondViewController.swift */,
 				EB26128C209863F100D62282 /* SplashViewController.swift */,
 				EB2310E3209D92570023A98D /* ThirdViewController.swift */,
+				94E130F12A8DD07700120F84 /* Logger.swift */,
 			);
 			path = Example;
 			sourceTree = "<group>";
@@ -1037,6 +1040,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				EB7867F9209722050071D524 /* AppDelegate.swift in Sources */,
+				94E130F22A8DD07700120F84 /* Logger.swift in Sources */,
 				EB7867FB209722050071D524 /* FirstViewController.swift in Sources */,
 				EB2310E2209D91640023A98D /* SecondViewController.swift in Sources */,
 				EB26128D209863F100D62282 /* SplashViewController.swift in Sources */,

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -252,8 +252,8 @@ final class EventInteractorImpl: EventInteractor {
                         })
                     do {
                         try self?.eventDao.delete(ids: deletedIds)
-                        completion?(.success(true))
                         self?.updateEventsAndNotify()
+                        completion?(.success(true))
                     } catch let error {
                         completion?(.failure(BKTError(error: error)))
                     }
@@ -322,11 +322,7 @@ final class EventInteractorImpl: EventInteractor {
     private func updateEventsAndNotify() {
         do {
             let events = try eventDao.getEvents()
-            // Update listeners should be called on the main thread
-            // to avoid unintentional lock on Interactor's execution thread.
-            DispatchQueue.main.async { [weak self] in
-                self?.eventUpdateListener?.onUpdate(events: events)
-            }
+            eventUpdateListener?.onUpdate(events: events)
         } catch let error {
             logger?.error(error)
         }

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -84,9 +84,7 @@ final class ApiClientImpl: ApiClient {
             completion: { (result: Result<(RegisterEventsResponse, URLResponse), Error>) in
                 switch result {
                 case .success((let response, _)):
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                        completion?(.success(response))
-                    }
+                    completion?(.success(response))
                 case .failure(let error):
                     completion?(.failure(.init(error: error)))
                 }

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -84,7 +84,9 @@ final class ApiClientImpl: ApiClient {
             completion: { (result: Result<(RegisterEventsResponse, URLResponse), Error>) in
                 switch result {
                 case .success((let response, _)):
-                    completion?(.success(response))
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                        completion?(.success(response))
+                    }
                 case .failure(let error):
                     completion?(.failure(.init(error: error)))
                 }

--- a/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
@@ -28,7 +28,9 @@ final class EvaluationForegroundTask: ScheduledTask {
             queue: queue,
             logger: component.config.logger,
             handler: { [weak self] _ in
-                self?.fetchEvaluations()
+                self?.queue.async {
+                    self?.fetchEvaluations()
+                }
             }
         )
         poller?.start()

--- a/Bucketeer/Sources/Internal/Scheduler/EventBackgroundTask.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/EventBackgroundTask.swift
@@ -38,10 +38,12 @@ final class EventBackgroundTask {
         scheduleAppRefresh()
 
         guard let component = self.component else { return }
-        BKTClient.flushSync(component: component) { [weak self] error in
-            task?.setTaskCompleted(success: error == nil)
-            if let error {
-                self?.component?.config.logger?.error(error)
+        queue.async {
+            BKTClient.flushSync(component: component) { [weak self] error in
+                task?.setTaskCompleted(success: error == nil)
+                if let error {
+                    self?.component?.config.logger?.error(error)
+                }
             }
         }
         // Provide the background task with an expiration handler that cancels the operation.

--- a/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
@@ -39,7 +39,7 @@ final class TaskScheduler {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(onBackground),
-                name: UIScene.didEnterBackgroundNotification,
+                name: UIScene.willDeactivateNotification,
                 object: nil
             )
         } else {
@@ -58,7 +58,7 @@ final class TaskScheduler {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(onBackground),
-                name: UIApplication.didEnterBackgroundNotification,
+                name: UIApplication.willResignActiveNotification,
                 object: nil
             )
         }

--- a/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
@@ -27,7 +27,7 @@ final class TaskScheduler {
             NotificationCenter.default.addObserver(
                 self,
                 selector: #selector(onForeground),
-                name: UIScene.willConnectNotification,
+                name: UIScene.didActivateNotification,
                 object: nil
             )
             NotificationCenter.default.addObserver(

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -64,19 +64,19 @@ class ApiClientTests: XCTestCase {
         api.getEvaluations(
             user: .mock1,
             userEvaluationsId: userEvaluationsId) { result in
-                switch result {
-                case .success(let response):
-                    XCTAssertEqual(response.evaluations.evaluations, evaluations)
-                    XCTAssertEqual(response.evaluations.id, userEvaluationsId)
-                    XCTAssertEqual(response.userEvaluationsId, userEvaluationsId)
-                    XCTAssertNotEqual(response.seconds, 0)
-                    XCTAssertNotEqual(response.sizeByte, 0)
-                    XCTAssertEqual(response.featureTag, "tag1")
-                case .failure(let error, _):
-                    XCTFail("\(error)")
-                }
-                expectation.fulfill()
+            switch result {
+            case .success(let response):
+                XCTAssertEqual(response.evaluations.evaluations, evaluations)
+                XCTAssertEqual(response.evaluations.id, userEvaluationsId)
+                XCTAssertEqual(response.userEvaluationsId, userEvaluationsId)
+                XCTAssertNotEqual(response.seconds, 0)
+                XCTAssertNotEqual(response.sizeByte, 0)
+                XCTAssertEqual(response.featureTag, "tag1")
+            case .failure(let error, _):
+                XCTFail("\(error)")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -130,15 +130,15 @@ class ApiClientTests: XCTestCase {
         api.getEvaluations(
             user: .mock1,
             userEvaluationsId: userEvaluationsId) { result in
-                switch result {
-                case .success:
-                    XCTFail()
-                case .failure(let error, let featureTag):
-                    XCTAssertEqual(error, .badRequest(message: "invalid parameter"))
-                    XCTAssertEqual(featureTag, "tag1")
-                }
-                expectation.fulfill()
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error, let featureTag):
+                XCTAssertEqual(error, .badRequest(message: "invalid parameter"))
+                XCTAssertEqual(featureTag, "tag1")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -253,7 +253,7 @@ class ApiClientTests: XCTestCase {
             }
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 1)
+        wait(for: [expectation], timeout: 10)
     }
 
     func testRegisterEventsErrorBody() throws {
@@ -434,14 +434,14 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success((let response, _)):
-                    XCTAssertEqual(response, mockResponse)
-                case .failure(let error):
-                    XCTFail("\(error)")
-                }
-                expectation.fulfill()
+            switch result {
+            case .success((let response, _)):
+                XCTAssertEqual(response, mockResponse)
+            case .failure(let error):
+                XCTFail("\(error)")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -496,14 +496,14 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: 200) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success((let response, _)):
-                    XCTAssertEqual(response, mockResponse)
-                case .failure(let error):
-                    XCTFail("\(error)")
-                }
-                expectation.fulfill()
+            switch result {
+            case .success((let response, _)):
+                XCTAssertEqual(response, mockResponse)
+            case .failure(let error):
+                XCTFail("\(error)")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -557,14 +557,14 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: 100) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success((let response, _)):
-                    XCTAssertEqual(response, mockResponse)
-                case .failure(let error):
-                    XCTFail("\(error)")
-                }
-                expectation.fulfill()
+            switch result {
+            case .success((let response, _)):
+                XCTAssertEqual(response, mockResponse)
+            case .failure(let error):
+                XCTFail("\(error)")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -610,20 +610,20 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success:
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard
+                    let error = error as? ResponseError,
+                    case .unknown(let urlResponse) = error else {
                     XCTFail()
-                case .failure(let error):
-                    guard
-                        let error = error as? ResponseError,
-                        case .unknown(let urlResponse) = error else {
-                        XCTFail()
-                        return
-                    }
-                    XCTAssertNil(urlResponse)
+                    return
                 }
-                expectation.fulfill()
+                XCTAssertNil(urlResponse)
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -669,18 +669,18 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success:
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard let error = error as? SomeError else {
                     XCTFail()
-                case .failure(let error):
-                    guard let error = error as? SomeError else {
-                        XCTFail()
-                        return
-                    }
-                    XCTAssertEqual(error, .failed)
+                    return
                 }
-                expectation.fulfill()
+                XCTAssertEqual(error, .failed)
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -728,20 +728,20 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success:
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard
+                    let error = error as? ResponseError,
+                    case .unknown(let urlResponse) = error else {
                     XCTFail()
-                case .failure(let error):
-                    guard
-                        let error = error as? ResponseError,
-                        case .unknown(let urlResponse) = error else {
-                        XCTFail()
-                        return
-                    }
-                    XCTAssertNil(urlResponse)
+                    return
                 }
-                expectation.fulfill()
+                XCTAssertNil(urlResponse)
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -793,20 +793,20 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success:
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard
+                    let error = error as? DecodingError,
+                    case .keyNotFound(let codingKey, _) = error else {
                     XCTFail()
-                case .failure(let error):
-                    guard
-                        let error = error as? DecodingError,
-                        case .keyNotFound(let codingKey, _) = error else {
-                        XCTFail()
-                        return
-                    }
-                    XCTAssertEqual(codingKey.stringValue, "error")
+                    return
                 }
-                expectation.fulfill()
+                XCTAssertEqual(codingKey.stringValue, "error")
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 
@@ -837,18 +837,18 @@ class ApiClientTests: XCTestCase {
             requestBody: mockRequestBody,
             path: path,
             timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
-                switch result {
-                case .success:
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard let error = error as? SomeError else {
                     XCTFail()
-                case .failure(let error):
-                    guard let error = error as? SomeError else {
-                        XCTFail()
-                        return
-                    }
-                    XCTAssertEqual(error, .failed)
+                    return
                 }
-                expectation.fulfill()
+                XCTAssertEqual(error, .failed)
             }
+            expectation.fulfill()
+        }
         wait(for: [expectation], timeout: 1)
     }
 }

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -255,7 +255,7 @@ final class BKTClientTests: XCTestCase {
             XCTAssertEqual(error, nil)
             expectation.fulfill()
         }
-        wait(for: [expectation], timeout: 100)
+        wait(for: [expectation], timeout: 0.1)
     }
 
     func testFlushFailure() {
@@ -267,7 +267,6 @@ final class BKTClientTests: XCTestCase {
             apiClient: MockApiClient(registerEventsHandler: { events, handler in
                 XCTAssertEqual(events, [.mockGoal1, .mockEvaluation1])
                 handler?(.failure(.apiServer(message: "unknown")))
-                print("expectation.fulfill() 1")
                 expectation.fulfill()
             }),
             eventDao: MockEventDao(getEventsHandler: {
@@ -276,7 +275,6 @@ final class BKTClientTests: XCTestCase {
                     // 1- for prepare for flushing
                     // 2- for checking duplicate
                     // 3- for prepare send update to the listener
-                    print("expectation.fulfill() 2")
                     expectation.fulfill()
                 }
                 return [.mockGoal1, .mockEvaluation1]
@@ -285,7 +283,6 @@ final class BKTClientTests: XCTestCase {
         let client = BKTClient(dataModule: dataModule, dispatchQueue: .global())
         client.flush { error in
             XCTAssertEqual(error, .apiServer(message: "unknown"))
-            print("expectation.fulfill() 3")
             expectation.fulfill()
         }
         wait(for: [expectation], timeout: 0.1)

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -619,7 +619,7 @@ final class EventInteractorTests: XCTestCase {
             }
         })
 
-        let interactor = self.eventInteractor(api: api, dao: dao)
+        let interactor = self.eventInteractor(api: api, dao: dao, config: BKTConfig.mock(eventsMaxQueueSize: 1))
         var listenCount = 0
         let listener = MockEventUpdateListener { events in
             if (listenCount == 0) {
@@ -649,23 +649,24 @@ final class EventInteractorTests: XCTestCase {
                     XCTFail()
                 }
                 expectation.fulfill()
-            })
-            // New event added
-            do {
-                try dao.add(events: addedEvents2)
-            } catch {
-                XCTFail(error.localizedDescription)
-            }
 
-            // Send all again
-            interactor.sendEvents(force: true, completion: { result in
-                switch result {
-                case .success(let success):
-                    XCTAssertTrue(success)
-                case .failure:
-                    XCTFail()
+                // New event added
+                do {
+                    try dao.add(events: addedEvents2)
+                } catch {
+                    XCTFail(error.localizedDescription)
                 }
-                expectation.fulfill()
+
+                // Send all again
+                interactor.sendEvents(force: true, completion: { result in
+                    switch result {
+                    case .success(let success):
+                        XCTAssertTrue(success)
+                    case .failure:
+                        XCTFail()
+                    }
+                    expectation.fulfill()
+                })
             })
 
             // Send all again, but no more to send

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -578,12 +578,12 @@ final class EventInteractorTests: XCTestCase {
         expectation.assertForOverFulfill = true
         expectation.expectedFulfillmentCount = 7
 
-        let addedEvents1: [Event] = [.mockEvaluation1, .mockGoal1]
+        let addedEvents1: [Event] = [.mockEvaluation1, .mockGoal1, .mockMetricsResponseLatency1]
         let addedEvents2: [Event] = [.mockEvaluation2, .mockGoal2]
         let dao = MockEventDao()
         try dao.add(events: addedEvents1)
 
-        XCTAssertEqual(dao.events.count, 2)
+        XCTAssertEqual(dao.events.count, 3)
         XCTAssertEqual(dao.events, addedEvents1)
 
         var requestCount = 0
@@ -593,7 +593,7 @@ final class EventInteractorTests: XCTestCase {
             // the second request should send `addedEvents2`
             // finally no more call
             if (requestCount == 0) {
-                XCTAssertEqual(events.count, 2)
+                XCTAssertEqual(events.count, 3)
                 XCTAssertEqual(events, addedEvents1)
                 // Delay
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3) {

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -623,11 +623,11 @@ final class EventInteractorTests: XCTestCase {
 
         let listener = MockEventUpdateListener { events in
             if (listenCount == 0) {
-                XCTAssertEqual(events.count, 2)
-                XCTAssertEqual(events, addedEvents2)
+                XCTAssertEqual(events.count, 0)
                 expectation.fulfill()
             } else if (listenCount == 1) {
-                XCTAssertEqual(events.count, 0)
+                XCTAssertEqual(events.count, 2)
+                XCTAssertEqual(events, addedEvents2)
                 expectation.fulfill()
             } else if (listenCount == 2) {
                 XCTAssertEqual(events.count, 0)

--- a/BucketeerTests/Mock/MockApiClient.swift
+++ b/BucketeerTests/Mock/MockApiClient.swift
@@ -24,4 +24,45 @@ final class MockApiClient: ApiClient {
         registerEventsHandler?(events, completion)
     }
 }
+
+final class MockSynchronizedApiClient: ApiClient {
+    typealias GetEvaluationsHandler = ((User, String, Int64?, ((GetEvaluationsResult) -> Void)?)) -> Void
+    typealias RegisterEventsHandler = ([Event], ((Result<RegisterEventsResponse, BKTError>) -> Void)?) -> Void
+
+    let getEvaluationsHandler: GetEvaluationsHandler?
+    let registerEventsHandler: RegisterEventsHandler?
+    let networkQueue = DispatchQueue(label: "io.bucketeer.concurrentQueue.network", attributes: .concurrent)
+    let semaphore = DispatchSemaphore(value: 0)
+
+    deinit {
+        semaphore.signal()
+    }
+
+    init(getEvaluationsHandler: GetEvaluationsHandler? = nil,
+         registerEventsHandler: RegisterEventsHandler? = nil) {
+        self.getEvaluationsHandler = getEvaluationsHandler
+        self.registerEventsHandler = registerEventsHandler
+    }
+
+    func getEvaluations(user: User, userEvaluationsId: String, timeoutMillis: Int64?, completion: ((GetEvaluationsResult) -> Void)?) {
+        networkQueue.asyncAfter(deadline: .now() + 3) { [weak self] in
+            self?.semaphore.signal()
+            debugPrint("getEvaluations unlocked")
+        }
+        debugPrint("getEvaluations wait")
+        semaphore.wait()
+        getEvaluationsHandler?((user, userEvaluationsId, timeoutMillis, completion))
+    }
+
+    func registerEvents(events: [Event], completion: ((Result<RegisterEventsResponse, BKTError>) -> Void)?) {
+        networkQueue.asyncAfter(deadline: .now() + 3) { [weak self] in
+            debugPrint("registerEvents unlocked")
+            self?.semaphore.signal()
+        }
+        debugPrint("registerEvents wait")
+        semaphore.wait()
+        registerEventsHandler?(events, completion)
+    }
+}
+
 // swiftlint:enable large_tuple

--- a/BucketeerTests/Mock/MockSession.swift
+++ b/BucketeerTests/Mock/MockSession.swift
@@ -7,9 +7,14 @@ struct MockSession: Session {
     var data: Data?
     var response: HTTPURLResponse?
     var error: Error?
+    let networkQueue = DispatchQueue(label: "io.bucketeer.concurrentQueue.network", attributes: .concurrent)
 
     func task(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
-        requestHandler?(request)
-        completionHandler(data, response, error)
+        networkQueue.async {
+            requestHandler?(request)
+            networkQueue.asyncAfter(deadline: .now() + 0.1) {
+                completionHandler(data, response, error)
+            }
+        }
     }
 }

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -67,6 +67,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .with(featureTag: "ios")
             .with(pollingInterval: 5_000)
             .with(appVersion: bundle.infoDictionary?["CFBundleShortVersionString"] as! String)
+            .with(logger: AppLogger())
 
         return try! builder.build()
     }
@@ -82,7 +83,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             featureTag: "ios",
             pollingInterval: 5_000,
             appVersion: bundle.infoDictionary?["CFBundleShortVersionString"] as! String,
-            logger: nil
+            logger: AppLogger()
         )
     }
 

--- a/Example/Logger.swift
+++ b/Example/Logger.swift
@@ -1,0 +1,20 @@
+import Foundation
+import Bucketeer
+
+final class AppLogger: BKTLogger {
+    private var prefix: String {
+        ""
+    }
+
+    func debug(message: String) {
+        print("\(prefix)[DEBUG] \(message)")
+    }
+
+    func warn(message: String) {
+        print("\(prefix)[WARN] \(message)")
+    }
+
+    func error(_ error: Error) {
+        print("\(prefix)[ERROR] \(error)")
+    }
+}


### PR DESCRIPTION
This PR should fix #29  (related to #23) 
# Changes 
- fix: send event deadlock on `EvaluationInteractor`
- removed: semaphore from `EvaluationInteractor`, 
- using semaphore for making API client run synchronized