### PR TITLE
fix: evaluation polling interval setting

### DIFF
--- a/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/EvaluationForegroundTask.swift
@@ -24,7 +24,7 @@ final class EvaluationForegroundTask: ScheduledTask {
         self.stop()
         guard let component = component else { return }
         self.poller = .init(
-            intervalMillis: isRetrying ? retryPollingInterval : component.config.eventsFlushInterval,
+            intervalMillis: isRetrying ? retryPollingInterval : component.config.pollingInterval,
             queue: queue,
             logger: component.config.logger,
             handler: { [weak self] _ in

--- a/BucketeerTests/EvaluationForegroundTaskTests.swift
+++ b/BucketeerTests/EvaluationForegroundTaskTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class EvaluationForegroundTaskTests: XCTestCase {
     func testStartAndReceiveSuccess() {
         let expectation = self.expectation(description: "")
-        expectation.expectedFulfillmentCount = 10
+        expectation.expectedFulfillmentCount = 3
         expectation.assertForOverFulfill = true
         let dispatchQueue = DispatchQueue(label: "default", qos: .default)
 
@@ -33,7 +33,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         let config = BKTConfig.mock(
             eventsFlushInterval: 10,
             eventsMaxQueueSize: 3,
-            pollingInterval: 5000,
+            pollingInterval: 5000, // The minimum polling interval is 60 seconds, but is set to 5 seconds to shorten the test.
             backgroundPollingInterval: 1000
         )
         let component = MockComponent(
@@ -79,7 +79,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         let config = BKTConfig.mock(
             eventsFlushInterval: 50,
             eventsMaxQueueSize: 3,
-            pollingInterval: 5000,
+            pollingInterval: 5000, // The minimum polling interval is 60 seconds, but is set to 5 seconds to shorten the test.
             backgroundPollingInterval: 1000
         )
 

--- a/BucketeerTests/EvaluationForegroundTaskTests.swift
+++ b/BucketeerTests/EvaluationForegroundTaskTests.swift
@@ -33,7 +33,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         let config = BKTConfig.mock(
             eventsFlushInterval: 10,
             eventsMaxQueueSize: 3,
-            pollingInterval: 100,
+            pollingInterval: 5000,
             backgroundPollingInterval: 1000
         )
         let component = MockComponent(
@@ -47,7 +47,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         )
         task.start()
 
-        wait(for: [expectation], timeout: 0.3)
+        wait(for: [expectation], timeout: 20)
     }
 
     func testStartAndReceiveError() {
@@ -79,7 +79,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         let config = BKTConfig.mock(
             eventsFlushInterval: 50,
             eventsMaxQueueSize: 3,
-            pollingInterval: 100,
+            pollingInterval: 5000,
             backgroundPollingInterval: 1000
         )
 
@@ -98,7 +98,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         )
         task.start()
 
-        wait(for: [expectation], timeout: 0.1)
+        wait(for: [expectation], timeout: 20)
     }
 
     func testStop() {

--- a/Example/AppDelegate.swift
+++ b/Example/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             .with(apiKey: apiKey)
             .with(apiEndpoint: apiEndpoint)
             .with(featureTag: "ios")
-            .with(pollingInterval: 5_000)
+            .with(pollingInterval: 150_000)
             .with(appVersion: bundle.infoDictionary?["CFBundleShortVersionString"] as! String)
 
         return try! builder.build()
@@ -80,7 +80,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             apiKey: apiKey,
             apiEndpoint: apiEndpoint,
             featureTag: "ios",
-            pollingInterval: 5_000,
+            pollingInterval: 150_000,
             appVersion: bundle.infoDictionary?["CFBundleShortVersionString"] as! String,
             logger: nil
         )


### PR DESCRIPTION
- This PR fixes the bug unable to set polling interval.
  - The value of the events flush interval was set to the evaluation polling interval by mistake.
- And changes the example application's polling interval setting to 150 seconds from 5 seconds.
  - The minimum polling interval is 60 seconds, and if a lower value is specified, it is automatically reset to 60 seconds. It creates confusion for users of the example app.
  - Also, I prefer to set a different value from the events flush interval.