### PR TITLE
fix: evaluation scheduler not being reset when the request succeeds

### DIFF
--- a/BucketeerTests/E2E/BucketeerE2ETests.swift
+++ b/BucketeerTests/E2E/BucketeerE2ETests.swift
@@ -73,9 +73,9 @@ final class BucketeerE2ETests: XCTestCase {
             let actual = client.evaluationDetails(featureId: FEATURE_ID_INT)
 
             assertEvaluation(actual: actual, expected: .init(
-                id: "feature-ios-e2e-integer:3:bucketeer-ios-user-id-1",
+                id: "feature-ios-e2e-integer:4:bucketeer-ios-user-id-1",
                 featureId: FEATURE_ID_INT,
-                featureVersion: 3,
+                featureVersion: 4,
                 variationId: "9c5fd2d2-d587-4ba2-8de2-0fc9454d564e",
                 variationName: "variation 10",
                 variationValue: "10",

--- a/BucketeerTests/EvaluationForegroundTaskTests.swift
+++ b/BucketeerTests/EvaluationForegroundTaskTests.swift
@@ -4,7 +4,7 @@ import XCTest
 final class EvaluationForegroundTaskTests: XCTestCase {
     func testStartAndReceiveSuccess() {
         let expectation = self.expectation(description: "")
-        expectation.expectedFulfillmentCount = 3
+        expectation.expectedFulfillmentCount = 2
         expectation.assertForOverFulfill = true
         let dispatchQueue = DispatchQueue(label: "default", qos: .default)
 
@@ -93,7 +93,7 @@ final class EvaluationForegroundTaskTests: XCTestCase {
         let task = EvaluationForegroundTask(
             component: component,
             queue: dispatchQueue,
-            retryPollingInterval: 1,
+            retryPollingInterval: 1000,
             maxRetryCount: 5
         )
         task.start()


### PR DESCRIPTION
### Thins done

- Fixed the evaluation scheduler not being reset when the request succeeds when the first attempt failed
- Refactor the reschedule function to keep the consistency with the Android SDK