### PR TITLE
fix: crash when flushing and destroy the client

### DIFF
--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -5,6 +5,7 @@ protocol Component: AnyObject {
     var userHolder: UserHolder { get }
     var evaluationInteractor: EvaluationInteractor { get }
     var eventInteractor: EventInteractor { get }
+    
     func destroy()
 }
 

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -5,7 +5,7 @@ protocol Component: AnyObject {
     var userHolder: UserHolder { get }
     var evaluationInteractor: EvaluationInteractor { get }
     var eventInteractor: EventInteractor { get }
-    
+
     func destroy()
 }
 

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -46,7 +46,7 @@ final class ComponentImpl: Component {
     var userHolder: UserHolder {
         dataModule.userHolder
     }
-    
+
     func destroy() {
         eventInteractor.set(eventUpdateListener: nil)
         evaluationInteractor.clearUpdateListeners()

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -5,6 +5,11 @@ protocol Component: AnyObject {
     var userHolder: UserHolder { get }
     var evaluationInteractor: EvaluationInteractor { get }
     var eventInteractor: EventInteractor { get }
+    func destroy()
+}
+
+extension Component {
+    func destroy() {}
 }
 
 final class ComponentImpl: Component {
@@ -40,5 +45,11 @@ final class ComponentImpl: Component {
 
     var userHolder: UserHolder {
         dataModule.userHolder
+    }
+    
+    func destroy() {
+        eventInteractor.set(eventUpdateListener: nil)
+        evaluationInteractor.clearUpdateListeners()
+        dataModule.apiClient.cancelAllOngoingRequest()
     }
 }

--- a/Bucketeer/Sources/Internal/DI/DataModule.swift
+++ b/Bucketeer/Sources/Internal/DI/DataModule.swift
@@ -33,7 +33,7 @@ final class DataModuleImpl: DataModule {
         apiEndpoint: config.apiEndpoint,
         apiKey: self.config.apiKey,
         featureTag: self.config.featureTag,
-        session: URLSession.shared,
+        session: URLSession(configuration: .default),
         logger: self.config.logger
     )
     private(set) lazy var userHolder: UserHolder = UserHolder(user: self.user)

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Error.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Error.swift
@@ -45,18 +45,18 @@ extension SQLite {
         }
 
         struct Info: Equatable, CustomDebugStringConvertible {
-            let pointer: OpaquePointer
+            let errorMessage: String
             let result: Int32
 
             var userInfo: [String: Any] {
                 return [
-                    NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(pointer)),
+                    NSLocalizedDescriptionKey: errorMessage,
                     "SQLiteHelperErrorResult": self.result
                 ]
             }
 
             var debugDescription: String {
-                String(cString: sqlite3_errmsg(pointer))
+                errorMessage
             }
         }
     }

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Statement.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Statement.swift
@@ -13,7 +13,7 @@ extension SQLite {
         func step() throws -> Bool {
             let result = sqlite3_step(pointer)
             guard result == SQLITE_ROW || result == SQLITE_DONE else {
-                throw Error.failedToStep(.init(pointer: pointer, result: result))
+                throw Error.failedToStep(.init(errorMessage: pointer.readErrorMessage(), result: result))
             }
             return result == SQLITE_ROW
         }
@@ -31,7 +31,7 @@ extension SQLite {
                 throw Error.unsupportedType
             }
             guard result == SQLITE_OK else {
-                throw Error.failedToBind(.init(pointer: pointer, result: result))
+                throw Error.failedToBind(.init(errorMessage: pointer.readErrorMessage(), result: result))
             }
             return self
         }
@@ -51,14 +51,14 @@ extension SQLite {
         func reset() throws {
             let result = sqlite3_reset(pointer)
             guard result == SQLITE_OK else {
-                throw Error.failedToFinalize(.init(pointer: pointer, result: result))
+                throw Error.failedToFinalize(.init(errorMessage: pointer.readErrorMessage(), result: result))
             }
         }
 
         func finalize() throws {
             let result = sqlite3_finalize(pointer)
             guard result == SQLITE_OK else {
-                throw Error.failedToFinalize(.init(pointer: pointer, result: result))
+                throw Error.failedToFinalize(.init(errorMessage: pointer.readErrorMessage(), result: result))
             }
         }
     }
@@ -96,3 +96,10 @@ private extension OpaquePointer {
         return Data(buffer: i8bufptr)
     }
 }
+
+extension OpaquePointer {
+    func readErrorMessage() -> String {
+        return String(cString: sqlite3_errmsg(self))
+    }
+}
+

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Statement.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.Statement.swift
@@ -102,4 +102,3 @@ extension OpaquePointer {
         return String(cString: sqlite3_errmsg(self))
     }
 }
-

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -38,7 +38,7 @@ final class SQLite {
             sqlite3_close_v2(dbConnection)
         }
     }
-    
+
     // note: any public method of this class `SQLite` should use the static func below to make sure it run on the `dbQueue`
     // that will prevent the crash with error `dispatch_queue_wait_forever`
     static func runSynchronouslyOnDBQueue<T>(block: () throws -> T) throws -> T {
@@ -56,7 +56,7 @@ final class SQLite {
 
 extension SQLite {
     func prepareStatement(sql: String) throws -> Statement {
-        try Self.runSynchronouslyOnDBQueue{
+        try Self.runSynchronouslyOnDBQueue {
             var _pointer: OpaquePointer?
             let result = sqlite3_prepare_v2(pointer, sql, -1, &_pointer, nil)
             guard result == SQLITE_OK,
@@ -81,7 +81,7 @@ extension SQLite {
     var userVersion: Int32 {
         get {
             do {
-                return try Self.runSynchronouslyOnDBQueue{
+                return try Self.runSynchronouslyOnDBQueue {
                     let statement = try prepareStatement(sql: "PRAGMA user_version")
                     try statement.step()
                     let userVersion = statement.int(at: 0)
@@ -96,7 +96,7 @@ extension SQLite {
         }
         set {
             do {
-                return try Self.runSynchronouslyOnDBQueue{
+                return try Self.runSynchronouslyOnDBQueue {
                     let statement = try prepareStatement(sql: "PRAGMA user_version = \(newValue)")
                     repeat {} while try statement.step()
                     try statement.reset()
@@ -158,7 +158,7 @@ extension SQLite {
     }
 
     func startTransaction(block: () throws -> Void) throws {
-        try Self.runSynchronouslyOnDBQueue{
+        try Self.runSynchronouslyOnDBQueue {
             // 1- begin transaction
             let beginTransactionQuery = "BEGIN;"
             let result = sqlite3_exec(pointer, beginTransactionQuery, nil, nil, nil)

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -41,7 +41,7 @@ final class SQLite {
 
     // note: any public method of this class `SQLite` should use the static func below to make sure it run on the `dbQueue`
     // that will prevent the crash with error `dispatch_queue_wait_forever`
-    static func runSynchronouslyOnDBQueue<T>(block: () throws -> T) throws -> T {
+    private static func runSynchronouslyOnDBQueue<T>(block: () throws -> T) throws -> T {
         if DispatchQueue.getSpecific(key: dispatchKey) == queueName {
             // If we have run in the `dbQueue` already
             // safe for run without `dbQueue.sync{}`

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -8,13 +8,15 @@ final class SQLite {
     // access SQLite on one serial queue to prevent `database is locked` or database corrupt
     private static let queueName = "io.bucketeer.SQLite"
     private static let dispatchKey = DispatchSpecificKey<String>()
-    private static let dbQueue = DispatchQueue(label: queueName)
+    private static let dbQueue : DispatchQueue = {
+        let queue = DispatchQueue(label: queueName)
+        queue.setSpecific(key: dispatchKey, value: queueName)
+        return queue
+    }()
 
     init(path: String, logger: Logger?) throws {
         self.path = path
         self.logger = logger
-        // set the queue key
-        Self.dbQueue.setSpecific(key: Self.dispatchKey, value: Self.queueName)
         pointer = try Self.dbQueue.sync {
             var _pointer: OpaquePointer?
             let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -5,31 +5,37 @@ final class SQLite {
     let path: String
     let pointer: OpaquePointer
     let logger: Logger?
+    // access SQLite on one serial queue to prevent `database is locked` or database corrupt
+    private static let dbQueue = DispatchQueue(label: "io.bucketeer.SQLite")
 
     init(path: String, logger: Logger?) throws {
         self.path = path
         self.logger = logger
-
-        sqlite3_shutdown()
-        sqlite3_initialize()
-
-        var _pointer: OpaquePointer?
-        let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
-        let result = sqlite3_open_v2(path, &_pointer, flags, nil)
-        if result != SQLITE_OK {
-            guard let pointer = _pointer else {
+        pointer = try Self.dbQueue.sync {
+            var _pointer: OpaquePointer?
+            let flags = SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX
+            let result = sqlite3_open_v2(path, &_pointer, flags, nil)
+            if result != SQLITE_OK {
+                guard let dbConnection = _pointer else {
+                    throw Error.unknown
+                }
+                throw Error.failedToOpen(.init(errorMessage: dbConnection.readErrorMessage(), result: result))
+            }
+            guard let dbConnection = _pointer else {
                 throw Error.unknown
             }
-            throw Error.failedToOpen(.init(pointer: pointer, result: result))
+            return dbConnection
         }
-        guard let pointer = _pointer else {
-            throw Error.unknown
-        }
-        self.pointer = pointer
+        // allow concurrent reads and writes https://www.sqlite.org/walformat.html
+        // its nice to have
+        try exec(query: "PRAGMA journal_mode = WAL")
     }
-
+    
     deinit {
-        sqlite3_close(pointer)
+        let dbConnection = pointer
+        Self.dbQueue.async {
+            sqlite3_close_v2(dbConnection)
+        }
     }
 }
 
@@ -38,97 +44,108 @@ extension SQLite {
         var _pointer: OpaquePointer?
         let result = sqlite3_prepare_v2(pointer, sql, -1, &_pointer, nil)
         guard result == SQLITE_OK,
-              let pointer = _pointer else {
-            throw Error.failedToPrepare(.init(pointer: pointer, result: result))
+            let pointer = _pointer else {
+            throw Error.failedToPrepare(.init(errorMessage: pointer.readErrorMessage(), result: result))
         }
         return .init(pointer: pointer)
     }
 
     func exec(query: String) throws {
-        let result = sqlite3_exec(pointer, query, nil, nil, nil)
-        guard result == SQLITE_OK else {
-            throw Error.failedToExecute(.init(pointer: pointer, result: result))
+        try Self.dbQueue.sync {
+            let result = sqlite3_exec(pointer, query, nil, nil, nil)
+            guard result == SQLITE_OK else {
+                throw Error.failedToExecute(.init(errorMessage: pointer.readErrorMessage(), result: result))
+            }
         }
     }
 }
 
 extension SQLite {
     var userVersion: Int32 {
-        get {
-            do {
-                let statement = try prepareStatement(sql: "PRAGMA user_version")
-                try statement.step()
-                let userVersion = statement.int(at: 0)
-                try statement.reset()
-                try statement.finalize()
-                return userVersion
-            } catch let error {
-                logger?.error(error)
-                return 0
-            }
-        }
-        set {
-            do {
-                let statement = try prepareStatement(sql: "PRAGMA user_version = \(newValue)")
-                repeat {} while try statement.step()
-                try statement.reset()
-                try statement.finalize()
-            } catch let error {
-                logger?.error(error)
-            }
-        }
-    }
+          get {
+              Self.dbQueue.sync {
+                  do {
+                      let statement = try prepareStatement(sql: "PRAGMA user_version")
+                      try statement.step()
+                      let userVersion = statement.int(at: 0)
+                      try statement.reset()
+                      try statement.finalize()
+                      return userVersion
+                  } catch let error {
+                      logger?.error(error)
+                      return 0
+                  }
+              }
+          }
+          set {
+              Self.dbQueue.sync {
+                  do {
+                      let statement = try prepareStatement(sql: "PRAGMA user_version = \(newValue)")
+                      repeat {} while try statement.step()
+                      try statement.reset()
+                      try statement.finalize()
+                  } catch let error {
+                      logger?.error(error)
+                  }
+              }
+          }
+      }
 }
 
 extension SQLite {
     func select<Entity: SQLiteEntity>(_ entity: Entity, conditions: [Condition]) throws -> [Entity.Model] {
-        let table = Table(entity: entity)
-        let sql = table.sqlToSelect(conditions: conditions)
-        let statement = try prepareStatement(sql: sql)
-
-        var models: [Entity.Model] = []
-        while try statement.step() {
-            do {
-                let model = try Entity.model(from: statement)
-                models.append(model)
-            } catch let error {
-                logger?.error(error)
+        try Self.dbQueue.sync {
+            let table = Table(entity: entity)
+            let sql = table.sqlToSelect(conditions: conditions)
+            let statement = try prepareStatement(sql: sql)
+            var models: [Entity.Model] = []
+            while (try statement.step()) {
+                do {
+                    let model = try Entity.model(from: statement)
+                    models.append(model)
+                } catch let error {
+                    logger?.error(error)
+                }
             }
+            try statement.reset()
+            try statement.finalize()
+            return models
         }
-        try statement.reset()
-        try statement.finalize()
-        return models
     }
 
     func insert<Entity: SQLiteEntity>(_ entities: [Entity]) throws {
-        for entity in entities {
-            let table = Table(entity: entity)
-            let sql = table.sqlToInsert()
-            var statement = try prepareStatement(sql: sql)
-            for column in table.columns {
-                statement = try statement.bind(name: column.name, value: column.column.anyValue)
+        try Self.dbQueue.sync {
+            for entity in entities {
+                let table = Table(entity: entity)
+                let sql = table.sqlToInsert()
+                var statement = try prepareStatement(sql: sql)
+                for column in table.columns {
+                    statement = try statement.bind(name: column.name, value: column.column.anyValue)
+                }
+                try statement.step()
+                try statement.reset()
+                try statement.finalize()
             }
+        }
+    }
+
+    func delete<Entity: SQLiteEntity>(_ entity: Entity, condition: Condition) throws {
+        try Self.dbQueue.sync {
+            let table = Table(entity: entity)
+            let sql = table.sqlToDelete(condition: condition)
+            let statement = try prepareStatement(sql: sql)
             try statement.step()
             try statement.reset()
             try statement.finalize()
         }
     }
 
-    func delete<Entity: SQLiteEntity>(_ entity: Entity, condition: Condition) throws {
-        let table = Table(entity: entity)
-        let sql = table.sqlToDelete(condition: condition)
-        let statement = try prepareStatement(sql: sql)
-        try statement.step()
-        try statement.reset()
-        try statement.finalize()
-    }
-
     func startTransaction(block: () throws -> Void) throws {
         let beginTransactionQuery = "BEGIN;"
         let result = sqlite3_exec(pointer, beginTransactionQuery, nil, nil, nil)
         guard result == SQLITE_OK else {
-            debugPrint("Failed to start transaction")
-            throw Error.failedToExecute(.init(pointer: pointer, result: result))
+            logger?.warn(message:"Failed to start transaction")
+            throw Error.failedToExecute(.init(errorMessage: pointer.readErrorMessage(), result: result))
         }
 
         do {
@@ -136,8 +153,8 @@ extension SQLite {
             let commitTransactionQuery = "COMMIT;"
             let commitResult = sqlite3_exec(pointer, commitTransactionQuery, nil, nil, nil)
             guard commitResult == SQLITE_OK else {
-                debugPrint("Failed to commit transaction")
-                throw Error.failedToExecute(.init(pointer: pointer, result: result))
+                logger?.warn(message:"Failed to commit transaction")
+                throw Error.failedToExecute(.init(errorMessage: pointer.readErrorMessage(), result: result))
             }
         } catch {
             try rollback()
@@ -148,11 +165,11 @@ extension SQLite {
 
     private func rollback() throws {
         let rollbackQuery = "ROLLBACK;"
-        debugPrint("Transaction rolled back")
+        logger?.warn(message:"Transaction rolled back")
         let result = sqlite3_exec(pointer, rollbackQuery, nil, nil, nil)
         guard result == SQLITE_OK else {
-            debugPrint("Failed to rollback transaction")
-            throw Error.failedToExecute(.init(pointer: pointer, result: result))
+            logger?.warn(message:"Failed to rollback transaction")
+            throw Error.failedToExecute(.init(errorMessage: pointer.readErrorMessage(), result: result))
         }
     }
 }

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -27,7 +27,7 @@ final class SQLite {
             return dbConnection
         }
     }
-    
+
     deinit {
         let dbConnection = pointer
         Self.dbQueue.async {
@@ -41,7 +41,7 @@ extension SQLite {
         var _pointer: OpaquePointer?
         let result = sqlite3_prepare_v2(pointer, sql, -1, &_pointer, nil)
         guard result == SQLITE_OK,
-            let pointer = _pointer else {
+              let pointer = _pointer else {
             throw Error.failedToPrepare(.init(errorMessage: pointer.readErrorMessage(), result: result))
         }
         return .init(pointer: pointer)
@@ -59,34 +59,34 @@ extension SQLite {
 
 extension SQLite {
     var userVersion: Int32 {
-          get {
-              Self.dbQueue.sync {
-                  do {
-                      let statement = try prepareStatement(sql: "PRAGMA user_version")
-                      try statement.step()
-                      let userVersion = statement.int(at: 0)
-                      try statement.reset()
-                      try statement.finalize()
-                      return userVersion
-                  } catch let error {
-                      logger?.error(error)
-                      return 0
-                  }
-              }
-          }
-          set {
-              Self.dbQueue.sync {
-                  do {
-                      let statement = try prepareStatement(sql: "PRAGMA user_version = \(newValue)")
-                      repeat {} while try statement.step()
-                      try statement.reset()
-                      try statement.finalize()
-                  } catch let error {
-                      logger?.error(error)
-                  }
-              }
-          }
-      }
+        get {
+            Self.dbQueue.sync {
+                do {
+                    let statement = try prepareStatement(sql: "PRAGMA user_version")
+                    try statement.step()
+                    let userVersion = statement.int(at: 0)
+                    try statement.reset()
+                    try statement.finalize()
+                    return userVersion
+                } catch let error {
+                    logger?.error(error)
+                    return 0
+                }
+            }
+        }
+        set {
+            Self.dbQueue.sync {
+                do {
+                    let statement = try prepareStatement(sql: "PRAGMA user_version = \(newValue)")
+                    repeat {} while try statement.step()
+                    try statement.reset()
+                    try statement.finalize()
+                } catch let error {
+                    logger?.error(error)
+                }
+            }
+        }
+    }
 }
 
 extension SQLite {

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -26,9 +26,6 @@ final class SQLite {
             }
             return dbConnection
         }
-        // allow concurrent reads and writes https://www.sqlite.org/walformat.html
-        // its nice to have
-        try exec(query: "PRAGMA journal_mode = WAL")
     }
     
     deinit {

--- a/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
+++ b/Bucketeer/Sources/Internal/Database/SQLite/SQLite.swift
@@ -161,7 +161,7 @@ extension SQLite {
 
     func startTransaction(block: () throws -> Void) throws {
         try Self.runSynchronouslyOnDBQueue {
-            // 1- begin transaction
+            // 1- begin
             let beginTransactionQuery = "BEGIN;"
             let result = sqlite3_exec(pointer, beginTransactionQuery, nil, nil, nil)
             guard result == SQLITE_OK else {
@@ -172,7 +172,7 @@ extension SQLite {
             do {
                 // 2- execute
                 try block()
-                // 3- commit transction
+                // 3- commit
                 let commitTransactionQuery = "COMMIT;"
                 let commitResult = sqlite3_exec(pointer, commitTransactionQuery, nil, nil, nil)
                 guard commitResult == SQLITE_OK else {

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -274,6 +274,7 @@ final class EventInteractorImpl: EventInteractor {
     }
 
     private func updateEventsAndNotify() {
+        guard eventUpdateListener != nil else { return }
         do {
             let events = try eventDao.getEvents()
             eventUpdateListener?.onUpdate(events: events)

--- a/Bucketeer/Sources/Internal/Remote/ApiClient.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClient.swift
@@ -26,6 +26,6 @@ extension ApiClient {
             completion: completion
         )
     }
-    
+
     func cancelAllOngoingRequest() {}
 }

--- a/Bucketeer/Sources/Internal/Remote/ApiClient.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClient.swift
@@ -9,6 +9,7 @@ protocol ApiClient {
         completion: ((GetEvaluationsResult) -> Void)?
     )
     func registerEvents(events: [Event], completion: ((Result<RegisterEventsResponse, BKTError>) -> Void)?)
+    func cancelAllOngoingRequest()
 }
 
 extension ApiClient {
@@ -25,4 +26,6 @@ extension ApiClient {
             completion: completion
         )
     }
+    
+    func cancelAllOngoingRequest() {}
 }

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -115,11 +115,11 @@ final class ApiClientImpl: ApiClient {
         timeoutMillis: Int64,
         encoder: JSONEncoder = JSONEncoder(),
         completion: ((Result<(Response, URLResponse), Error>) -> Void)?) {
-            if (closed) {
-                completion?(.failure(BKTError.illegalState(message: "API Client has been closed")))
-                return
-            }
-            
+        if (closed) {
+            completion?(.failure(BKTError.illegalState(message: "API Client has been closed")))
+            return
+        }
+
         let requestId = Date().unixTimestamp
         logger?.debug(message: "[API] RequestID enqueue: \(requestId)")
         logger?.debug(message: "[API] Register events: \(requestBody)")
@@ -191,7 +191,7 @@ final class ApiClientImpl: ApiClient {
             completion?(.failure(error))
         }
     }
-    
+
     func cancelAllOngoingRequest() {
         // we access API client from the SDK queue only, so its safe
         closed = true

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -11,6 +11,7 @@ final class ApiClientImpl: ApiClient {
     private let defaultRequestTimeoutMills: Int64
     private let logger: Logger?
     private let semaphore = DispatchSemaphore(value: 0)
+    private var closed = false
 
     deinit {
         // over-signaling does not introduce new problems
@@ -23,7 +24,7 @@ final class ApiClientImpl: ApiClient {
         apiKey: String,
         featureTag: String,
         defaultRequestTimeoutMills: Int64 = ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS,
-        session: Session = URLSession.shared,
+        session: Session,
         logger: Logger?
     ) {
 
@@ -114,6 +115,11 @@ final class ApiClientImpl: ApiClient {
         timeoutMillis: Int64,
         encoder: JSONEncoder = JSONEncoder(),
         completion: ((Result<(Response, URLResponse), Error>) -> Void)?) {
+            if (closed) {
+                completion?(.failure(BKTError.illegalState(message: "API Client has been closed")))
+                return
+            }
+            
         let requestId = Date().unixTimestamp
         logger?.debug(message: "[API] RequestID enqueue: \(requestId)")
         logger?.debug(message: "[API] Register events: \(requestBody)")
@@ -184,6 +190,12 @@ final class ApiClientImpl: ApiClient {
             logger?.debug(message: "[API] RequestID: \(requestId) could not request with error \(error.localizedDescription)")
             completion?(.failure(error))
         }
+    }
+    
+    func cancelAllOngoingRequest() {
+        // we access API client from the SDK queue only, so its safe
+        closed = true
+        session.invalidateAndCancel()
     }
 }
 

--- a/Bucketeer/Sources/Internal/Remote/Session.swift
+++ b/Bucketeer/Sources/Internal/Remote/Session.swift
@@ -4,6 +4,7 @@ protocol Session {
     var configuration: URLSessionConfiguration { get }
 
     func task(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void)
+    func invalidateAndCancel()
 }
 
 extension URLSession: Session {

--- a/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
@@ -83,7 +83,7 @@ final class TaskScheduler {
         foregroundSchedulers.forEach({ $0.stop() })
         backgroundSchedulers.forEach({ $0.stop() })
     }
-    
+
     func invalidate() {
         stop()
         foregroundSchedulers.removeAll()

--- a/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
+++ b/Bucketeer/Sources/Internal/Scheduler/TaskScheduler.swift
@@ -83,4 +83,10 @@ final class TaskScheduler {
         foregroundSchedulers.forEach({ $0.stop() })
         backgroundSchedulers.forEach({ $0.stop() })
     }
+    
+    func invalidate() {
+        stop()
+        foregroundSchedulers.removeAll()
+        backgroundSchedulers.removeAll()
+    }
 }

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -77,9 +77,6 @@ public class BKTClient {
 
 extension BKTClient {
     public static func initialize(config: BKTConfig, user: BKTUser, timeoutMillis: Int64 = 5000, completion: ((BKTError?) -> Void)? = nil) throws {
-        guard Thread.isMainThread else {
-            throw BKTError.illegalState(message: "the initialize method must be called on main thread")
-        }
         concurrentQueue.sync {
             guard BKTClient.default == nil else {
                 config.logger?.warn(message: "BKTClient is already initialized. Not sure if the initial fetch has finished")
@@ -104,9 +101,6 @@ extension BKTClient {
     }
 
     public static func destroy() throws {
-        guard Thread.isMainThread else {
-            throw BKTError.illegalState(message: "the destroy method must be called on main thread")
-        }
         concurrentQueue.sync {
             BKTClient.default?.destroy()
             BKTClient.default = nil

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -64,7 +64,7 @@ public class BKTClient {
             }
         }
     }
-    
+
     private func destroy() {
         taskScheduler?.invalidate()
         taskScheduler = nil

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -80,12 +80,12 @@ extension BKTClient {
         guard Thread.isMainThread else {
             throw BKTError.illegalState(message: "the initialize method must be called on main thread")
         }
-        guard BKTClient.default == nil else {
-            config.logger?.warn(message: "BKTClient is already initialized. Not sure if the initial fetch has finished")
-            completion?(nil)
-            return
-        }
         concurrentQueue.sync {
+            guard BKTClient.default == nil else {
+                config.logger?.warn(message: "BKTClient is already initialized. Not sure if the initial fetch has finished")
+                completion?(nil)
+                return
+            }
             do {
                 let dispatchQueue = DispatchQueue(label: "io.bucketeer.taskQueue")
                 let dataModule = try DataModuleImpl(user: user.toUser(), config: config)

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1018,5 +1018,59 @@ class ApiClientTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5)
     }
+    
+    func testCancelOngoingRequest() throws {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 2
+        expectation.assertForOverFulfill = true
+
+        let mockRequestBody = MockRequestBody()
+
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = "path"
+        let apiKey = "x:api-key"
+
+        let session = MockSession(
+            configuration: .default,
+            requestHandler: { request in
+                XCTFail("should not sending the request because the client has been closed")
+            },
+            data: nil,
+            response: nil,
+            error: nil,
+            invalidateAndCancelHandler: {
+                // Should invalidateAndCancel the session
+                expectation.fulfill()
+            }
+        )
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: apiKey,
+            featureTag: "tag1",
+            session: session,
+            logger: nil
+        )
+        
+        api.cancelAllOngoingRequest()
+        
+        api.send(
+            requestBody: mockRequestBody,
+            path: path,
+            timeoutMillis: ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS) { (result: Result<(MockResponse, URLResponse), Error>) in
+            switch result {
+            case .success:
+                XCTFail()
+            case .failure(let error):
+                guard
+                    let error = error as? BKTError,
+                    case .illegalState(message: "API Client has been closed") = error else {
+                    XCTFail("should be BKTError.illegalState")
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 0.1)
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1018,7 +1018,7 @@ class ApiClientTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 5)
     }
-    
+
     func testCancelOngoingRequest() throws {
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 2
@@ -1032,7 +1032,7 @@ class ApiClientTests: XCTestCase {
 
         let session = MockSession(
             configuration: .default,
-            requestHandler: { request in
+            requestHandler: { _ in
                 XCTFail("should not sending the request because the client has been closed")
             },
             data: nil,
@@ -1050,9 +1050,9 @@ class ApiClientTests: XCTestCase {
             session: session,
             logger: nil
         )
-        
+
         api.cancelAllOngoingRequest()
-        
+
         api.send(
             requestBody: mockRequestBody,
             path: path,

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -4,7 +4,7 @@ import XCTest
 // swiftlint:disable type_body_length file_length
 final class BKTClientTests: XCTestCase {
 
-    func testMainThreadRequired() throws {
+    func testMainThreadNotRequired() throws {
         let expectation = self.expectation(description: "")
         expectation.expectedFulfillmentCount = 4
 
@@ -19,9 +19,9 @@ final class BKTClientTests: XCTestCase {
                     user: user, completion: { _ in
                     }
                 )
-            } catch {
-                // Should catch error, because we didn't on the main thread
                 expectation.fulfill()
+            } catch {
+                XCTFail()
             }
 
             DispatchQueue.main.sync {
@@ -33,14 +33,16 @@ final class BKTClientTests: XCTestCase {
                     )
                     // Should success and fullfill
                     expectation.fulfill()
-                } catch {}
+                } catch {
+                    XCTFail()
+                }
             }
 
             do {
                 try BKTClient.destroy()
-            } catch {
-                // Should catch error, because we didn't on the main thread
                 expectation.fulfill()
+            } catch {
+                XCTFail()
             }
 
             DispatchQueue.main.sync {
@@ -48,7 +50,9 @@ final class BKTClientTests: XCTestCase {
                     try BKTClient.destroy()
                     // Should success and fullfill
                     expectation.fulfill()
-                } catch {}
+                } catch {
+                    XCTFail()
+                }
             }
         }
 

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -294,7 +294,7 @@ final class BKTClientTests: XCTestCase {
 
     func testFlushSuccess() {
         let expectation = self.expectation(description: "")
-        expectation.expectedFulfillmentCount = 4
+        expectation.expectedFulfillmentCount = 3
         expectation.assertForOverFulfill = true
         let dataModule = MockDataModule(
             userHolder: .init(user: .mock1),
@@ -323,7 +323,7 @@ final class BKTClientTests: XCTestCase {
 
     func testFlushFailure() {
         let expectation = self.expectation(description: "")
-        expectation.expectedFulfillmentCount = 5
+        expectation.expectedFulfillmentCount = 4
         expectation.assertForOverFulfill = true
         let dataModule = MockDataModule(
             userHolder: .init(user: .mock1),

--- a/BucketeerTests/Mock/MockSession.swift
+++ b/BucketeerTests/Mock/MockSession.swift
@@ -8,6 +8,7 @@ struct MockSession: Session {
     var response: HTTPURLResponse?
     var error: Error?
     let networkQueue = DispatchQueue(label: "io.bucketeer.concurrentQueue.network", attributes: .concurrent)
+    var invalidateAndCancelHandler: (() -> Void)?
 
     func task(with request: URLRequest, completionHandler: @escaping (Data?, URLResponse?, Error?) -> Void) {
         networkQueue.async {
@@ -19,6 +20,6 @@ struct MockSession: Session {
     }
     
     func invalidateAndCancel() {
-        
+        invalidateAndCancelHandler?()
     }
 }

--- a/BucketeerTests/Mock/MockSession.swift
+++ b/BucketeerTests/Mock/MockSession.swift
@@ -17,4 +17,8 @@ struct MockSession: Session {
             }
         }
     }
+    
+    func invalidateAndCancel() {
+        
+    }
 }

--- a/BucketeerTests/Mock/MockSession.swift
+++ b/BucketeerTests/Mock/MockSession.swift
@@ -18,7 +18,7 @@ struct MockSession: Session {
             }
         }
     }
-    
+
     func invalidateAndCancel() {
         invalidateAndCancelHandler?()
     }

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -29,32 +29,31 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1Wj-gS-Kj9">
-                                <rect key="frame" x="147" y="479" width="81" height="30"/>
+                                <rect key="frame" x="147" y="464" width="81" height="30"/>
                                 <state key="normal" title="Track Event"/>
                                 <connections>
                                     <action selector="trackButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="05K-qg-dCy"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cbc-Bw-Swy">
-                                <rect key="frame" x="139" y="529" width="97" height="30"/>
+                                <rect key="frame" x="139" y="514" width="97" height="30"/>
                                 <state key="normal" title="Destroy Client"/>
                                 <connections>
                                     <action selector="destroyClient:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1Ef-1a-TZx"/>
                                 </connections>
                             </button>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="COY-gG-Ynv">
-                                <rect key="frame" x="155" y="579" width="65" height="30"/>
+                                <rect key="frame" x="155" y="564" width="65" height="30"/>
                                 <state key="normal" title="Init Client"/>
                                 <connections>
                                     <action selector="initClient:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1WI-4V-NGZ"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xSt-m3-4KX">
-                                <rect key="frame" x="279" y="450" width="52" height="30"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <state key="normal" title="Crash ?"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xSt-m3-4KX">
+                                <rect key="frame" x="146" y="614" width="83" height="30"/>
+                                <state key="normal" title="Switch User"/>
                                 <connections>
-                                    <action selector="testCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YWM-3c-fiU"/>
+                                    <action selector="switchUser:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YWM-3c-fiU"/>
                                 </connections>
                             </button>
                         </subviews>
@@ -64,10 +63,12 @@
                             <constraint firstItem="Cbc-Bw-Swy" firstAttribute="top" secondItem="1Wj-gS-Kj9" secondAttribute="bottom" constant="20" id="4Nd-ed-C8z"/>
                             <constraint firstItem="ZYx-Q6-XF1" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="6vs-Ld-4wm"/>
                             <constraint firstItem="14b-lY-ZNI" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="JuB-Ek-0bV"/>
-                            <constraint firstItem="1Wj-gS-Kj9" firstAttribute="top" secondItem="ZYx-Q6-XF1" secondAttribute="bottom" constant="45" id="P8G-Fj-adC"/>
+                            <constraint firstItem="1Wj-gS-Kj9" firstAttribute="top" secondItem="ZYx-Q6-XF1" secondAttribute="bottom" constant="30" id="P8G-Fj-adC"/>
+                            <constraint firstItem="xSt-m3-4KX" firstAttribute="top" secondItem="COY-gG-Ynv" secondAttribute="bottom" constant="20" id="bqC-V4-uwZ"/>
                             <constraint firstItem="COY-gG-Ynv" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="cfI-1N-jbB"/>
                             <constraint firstItem="Cbc-Bw-Swy" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="dzZ-eV-Z2L"/>
                             <constraint firstItem="COY-gG-Ynv" firstAttribute="top" secondItem="Cbc-Bw-Swy" secondAttribute="bottom" constant="20" id="fRh-Nv-tEm"/>
+                            <constraint firstItem="xSt-m3-4KX" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="h2n-lc-XNX"/>
                             <constraint firstItem="ZYx-Q6-XF1" firstAttribute="top" secondItem="14b-lY-ZNI" secondAttribute="bottom" constant="60" id="hbX-Te-H5W"/>
                             <constraint firstItem="1Wj-gS-Kj9" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="jLJ-U2-PHy"/>
                             <constraint firstItem="14b-lY-ZNI" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="vRt-44-fFZ"/>

--- a/Example/Base.lproj/Main.storyboard
+++ b/Example/Base.lproj/Main.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eMj-K9-yXM">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="eMj-K9-yXM">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -47,6 +47,14 @@
                                 <state key="normal" title="Init Client"/>
                                 <connections>
                                     <action selector="initClient:" destination="BYZ-38-t0r" eventType="touchUpInside" id="1WI-4V-NGZ"/>
+                                </connections>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xSt-m3-4KX">
+                                <rect key="frame" x="279" y="450" width="52" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Crash ?"/>
+                                <connections>
+                                    <action selector="testCrash:" destination="BYZ-38-t0r" eventType="touchUpInside" id="YWM-3c-fiU"/>
                                 </connections>
                             </button>
                         </subviews>

--- a/Example/FirstViewController.swift
+++ b/Example/FirstViewController.swift
@@ -32,7 +32,7 @@ class FirstViewController: UIViewController {
     
     @IBAction func initClient(_ sender: Any) {
         let user = try! BKTUser.Builder()
-            .with(id: "001")
+            .with(id: "user_001")
             .with(attributes: [:])
             .build()
 
@@ -66,14 +66,15 @@ class FirstViewController: UIViewController {
         return try! builder.build()
     }
     
-    @IBAction func testCrash(_ sender: Any) {
+    @IBAction func switchUser(_ sender: Any) {
         let destroyAndInitialize: () -> Void = {
             do {
                 print("[Bucketeer] destroying ---------- ")
                 try BKTClient.destroy()
                 
+                // create new user with new userId
                 let user = try! BKTUser.Builder()
-                    .with(id: "001")
+                    .with(id: "user_002")
                     .with(attributes: [:])
                     .build()
                 let config = self.makeConfigUsingBuilder()

--- a/Example/FirstViewController.swift
+++ b/Example/FirstViewController.swift
@@ -65,6 +65,48 @@ class FirstViewController: UIViewController {
 
         return try! builder.build()
     }
+    
+    @IBAction func testCrash(_ sender: Any) {
+        let destroyAndInitialize: () -> Void = {
+            do {
+                print("[Bucketeer] destroying ---------- ")
+                try BKTClient.destroy()
+                
+                let user = try! BKTUser.Builder()
+                    .with(id: "001")
+                    .with(attributes: [:])
+                    .build()
+                let config = self.makeConfigUsingBuilder()
+                
+                print("[Bucketeer] initializing ---------- ")
+                try BKTClient.initialize(config: config, user: user) { error in
+                    DispatchQueue.main.async {
+                        if let error {
+                            print("[Bucketeer] ERROR initialize ------------------", error)
+                        } else {
+                            print("[Bucketeer] OK initialize ------------------")
+                        }
+                    }
+                }
+            } catch {
+                print("[Bucketeer] ERROR trying to destroy and initialize ------------------")
+            }
+        }
+        if let client = try? BKTClient.shared {
+            client.track(goalId: "ios_test_002", value: 1)
+            print("[Bucketeer] flushing ---------- ")
+            client.flush { error in
+                if let error {
+                    print("[Bucketeer] ERROR flushing ------------------", error)
+                    return
+                }
+                print("[Bucketeer] OK flushing ------------------")
+                destroyAndInitialize()
+            }
+        } else {
+            destroyAndInitialize()
+        }
+    }
 }
 
 extension UIColor {

--- a/Example/FirstViewController.swift
+++ b/Example/FirstViewController.swift
@@ -4,12 +4,11 @@ import Bucketeer
 class FirstViewController: UIViewController {
 
     @IBOutlet weak var messageLabel: UILabel!
-    var client : BKTClient?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         do {
-            try client = BKTClient.shared
+            _ = try BKTClient.shared
         } catch {
             // We may have an error when we did not success initialize the client
             // Handle error
@@ -17,13 +16,14 @@ class FirstViewController: UIViewController {
     }
     
     override func viewWillAppear(_ animated: Bool) {
-
+        let client = try? BKTClient.shared
         messageLabel.text = client?.stringVariation(featureId: "ios_test_002", defaultValue: "not found...") ?? "not found..."
 
         let colorCode = client?.stringVariation(featureId: "ios_test_003", defaultValue: "#999999") ?? "#999999"
         view.backgroundColor = UIColor(hex: colorCode)
     }
     @IBAction func trackButtonAction(_ sender: Any) {
+        let client = try? BKTClient.shared
         client?.track(goalId: "ios_test_002", value: 1)
     }
     @IBAction func destroyClient(_ sender: Any) {


### PR DESCRIPTION
# Changes 
- [x] Removed a database connection pointer from the database Error struct (it caused a memory leak and crash)
- [x] Only access SQLite from one database queue to prevent the error 'database locked', 'fail to close'..., or database corrupt 
- [x] ~~Enable WAL mode for the database to enable concurrency read & write in case we are open many database connection~~
- [x] Cancel any ongoing network request when destroy 
- [x] Move BKTClient.destroy() to the same queue as the BKTClient.init method    