### PR TITLE
chore: change to use `feature_id` for the active evaluations map

### DIFF
--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -87,6 +87,8 @@ final class EvaluationStorageImpl: EvaluationStorage {
             !archivedFeatureIds.contains(evaluation.featureId)
         }.map { item in
             item
+        }.sorted { evaluation1, evaluation2 in
+            evaluation1.featureId < evaluation2.featureId
         }
         // 4. Save to database
         try deleteAllAndInsert(userId: userId, evaluations: activeEvaluations, evaluatedAt: evaluatedAt)

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -88,6 +88,8 @@ final class EvaluationStorageImpl: EvaluationStorage {
         }.map { item in
             item
         }.sorted { evaluation1, evaluation2 in
+            // Make sure the order is correct,
+            // as dictionary is unorder
             evaluation1.featureId < evaluation2.featureId
         }
         // 4. Save to database

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -65,36 +65,32 @@ final class EvaluationStorageImpl: EvaluationStorage {
             try evaluationDao.deleteAll(userId: userId)
             try evaluationDao.put(userId: userId, evaluations: evaluations)
         }
-        // Update cache directly after we have force update
+        // Update cache directly
         evaluationMemCacheDao.set(key: userId, value: evaluations)
         self.evaluatedAt = evaluatedAt
     }
 
     func update(evaluations: [Evaluation], archivedFeatureIds: [String], evaluatedAt: String) throws -> Bool {
-        var activeEvaluations = [Evaluation]()
-        var archivedEvaluationIds = [String]()
-        try evaluationDao.startTransaction {
-            // 1. Update evaluation with new data
-            try evaluationDao.put(userId: userId, evaluations: evaluations)
-            // 2. Get current data in db
-            let evaluationsInDb = try evaluationDao.get(userId: userId)
-            // 3. Filter active & archived
-            for evaluation in evaluationsInDb {
-                if archivedFeatureIds.contains(evaluation.featureId) {
-                    archivedEvaluationIds.append(evaluation.id)
-                } else {
-                    activeEvaluations.append(evaluation)
-                }
+        // 1. Get current data in db
+        var activeEvaluationsDict = try evaluationDao.get(userId: userId)
+            .reduce([String:Evaluation]()) { (result, evaluation) -> [String:Evaluation] in
+                var result = result
+                result[evaluation.featureId] = evaluation
+                return result
             }
-            // 4. Remove all the evaluations which have the same id in the list archivedEvaluationIds
-            if (archivedEvaluationIds.count > 0) {
-                try evaluationDao.deleteByIds(archivedEvaluationIds)
-            }
+        // 2. Update evaluation with new data
+        for evaluation in evaluations {
+            activeEvaluationsDict[evaluation.featureId] = evaluation
         }
-        self.evaluatedAt = evaluatedAt
-        // 5. Save a new cache
-        evaluationMemCacheDao.set(key: userId, value: activeEvaluations)
-        return evaluations.count > 0 || archivedEvaluationIds.count > 0
+        // 3. Filter active
+        let activeEvaluations = activeEvaluationsDict.values.filter { evaluation in
+            !archivedFeatureIds.contains(evaluation.featureId)
+        }.map { item in
+            item
+        }
+        // 4. Save to database
+        try deleteAllAndInsert(userId: userId, evaluations: activeEvaluations, evaluatedAt: evaluatedAt)
+        return evaluations.count > 0 || archivedFeatureIds.count > 0
     }
 
     // getBy will return the data from the cache to speed up the response time

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -73,10 +73,10 @@ final class EvaluationStorageImpl: EvaluationStorage {
     func update(evaluations: [Evaluation], archivedFeatureIds: [String], evaluatedAt: String) throws -> Bool {
         // 1. Get current data in db
         var activeEvaluationsDict = try evaluationDao.get(userId: userId)
-            .reduce([String:Evaluation]()) { (result, evaluation) -> [String:Evaluation] in
-                var result = result
-                result[evaluation.featureId] = evaluation
-                return result
+            .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
+                var output = input
+                output[evaluation.featureId] = evaluation
+                return output
             }
         // 2. Update evaluation with new data
         for evaluation in evaluations {

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -82,18 +82,12 @@ final class EvaluationStorageImpl: EvaluationStorage {
         for evaluation in evaluations {
             currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
         }
-
         // 3. Filter active
         let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
             !archivedFeatureIds.contains(evaluation.featureId)
         }.map { item in
             item
-        }.sorted { evaluation1, evaluation2 in
-            // Make sure the order is correct,
-            // as dictionary is unorder
-            evaluation1.featureId < evaluation2.featureId
         }
-
         // 4. Save to database
         try deleteAllAndInsert(userId: userId, evaluations: currentEvaluations, evaluatedAt: evaluatedAt)
         return evaluations.count > 0 || archivedFeatureIds.count > 0

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -82,7 +82,7 @@ final class EvaluationStorageImpl: EvaluationStorage {
         for evaluation in evaluations {
             currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
         }
-        
+
         // 3. Filter active
         let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
             !archivedFeatureIds.contains(evaluation.featureId)

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -398,7 +398,7 @@ final class BKTClientTests: XCTestCase {
         client.fetchEvaluations(timeoutMillis: nil) { _ in
             let evaluation = client.evaluationDetails(featureId: "feature1")
             let expected = BKTEvaluation(
-                id: "evaluation1",
+                id: "feature1:1:user1",
                 featureId: "feature1",
                 featureVersion: 1,
                 userId: User.mock1.id,

--- a/BucketeerTests/EvaluationDaoTests.swift
+++ b/BucketeerTests/EvaluationDaoTests.swift
@@ -84,7 +84,7 @@ final class EvaluationDaoTests: XCTestCase {
         // Update
         let updatedValue = "variation - updated"
         let updatedMock = Evaluation(
-            id: "evaluation1",
+            id: "feature1:1:user1",
             featureId: "feature1",
             featureVersion: 1,
             userId: User.mock1.id,

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -524,7 +524,6 @@ final class EvaluationInteractorTests: XCTestCase {
     }
 
     func testChangeFeatureTagWillClearUserEvaluationsId() {
-        let baseUserEvaluationsId = UserEvaluations.mock1.id
         let api = MockApiClient()
         let storage = MockEvaluationStorage()
 

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -170,8 +170,7 @@ final class EvaluationStorageTests: XCTestCase {
         }, deleteAllHandler: { userId in
             expectation.fulfill()
             XCTAssertEqual(testUserId1, userId)
-
-        }, deleteByIdsHandlder: { ids in
+        }, deleteByIdsHandlder: { _ in
             XCTFail("should not called")
         }, startTransactionHandler: { block in
             // Should use use transaction

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -140,7 +140,7 @@ final class EvaluationStorageTests: XCTestCase {
         let mockDao = MockEvaluationDao(putHandler: { userId, evaluations in
             expectation.fulfill()
             XCTAssertEqual(testUserId1, userId)
-            XCTAssertEqual(evaluations, [mockEvaluationForUpsert, mockEvaluationForInsert])
+            XCTAssertEqual(Set(evaluations), Set([mockEvaluationForUpsert, mockEvaluationForInsert]))
         }, getHandler: { userId in
             // Should fullfill 2 times
             // 1 for init cache
@@ -194,8 +194,8 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertTrue(result, "update action should success")
         XCTAssertEqual(storage.evaluatedAt, "1024", "evaluatedAt should be 1024")
         XCTAssertEqual(
-            try storage.get(userId: testUserId1),
-            [mockEvaluationForUpsert, mockEvaluationForInsert],
+            Set(try storage.get(userId: testUserId1)),
+            Set([mockEvaluationForUpsert, mockEvaluationForInsert]),
             "expected [mock2Updated, mockEvaluationForInsert] in the database"
         )
         wait(for: [expectation], timeout: 0.1)

--- a/BucketeerTests/Mock/MockEvaluations.swift
+++ b/BucketeerTests/Mock/MockEvaluations.swift
@@ -5,7 +5,7 @@ extension Evaluation {
 
     /// id: evaluation1 - user: user1, value: string
     static let mock1 = Evaluation(
-        id: "evaluation1",
+        id: "feature1:1:user1",
         featureId: "feature1",
         featureVersion: 1,
         userId: User.mock1.id,
@@ -19,9 +19,9 @@ extension Evaluation {
     )
 
     static let mock1Updated = Evaluation(
-        id: "evaluation1_updated",
+        id: "feature1:2:user1",
         featureId: "feature1",
-        featureVersion: 1,
+        featureVersion: 2,
         userId: User.mock1.id,
         variationId: "variation1",
         variationName: "variation name1",
@@ -34,7 +34,7 @@ extension Evaluation {
 
     /// id: evaluation2 - user: user1, value: int
     static let mock2 = Evaluation(
-        id: "evaluation2",
+        id: "feature2:1:user1",
         featureId: "feature2",
         featureVersion: 1,
         userId: User.mock1.id,
@@ -49,7 +49,7 @@ extension Evaluation {
 
     /// id: evaluation3 - user: user2, value: double
     static let mock3 = Evaluation(
-        id: "evaluation3",
+        id: "feature3:1:user2",
         featureId: "feature3",
         featureVersion: 1,
         userId: User.mock2.id,
@@ -64,7 +64,7 @@ extension Evaluation {
 
     /// id: evaluation4 - user: user2, value: bool
     static let mock4 = Evaluation(
-        id: "evaluation4",
+        id: "feature4:1:user2",
         featureId: "feature4",
         featureVersion: 1,
         userId: User.mock2.id,
@@ -79,7 +79,7 @@ extension Evaluation {
 
     /// id: evaluation5 - user: user2, value: json
     static let mock5 = Evaluation(
-        id: "evaluation5",
+        id: "feature5:1:user2",
         featureId: "feature5",
         featureVersion: 1,
         userId: User.mock2.id,


### PR DESCRIPTION
# Changes
- Using feature_id to upset list active evaluations
- This PR should fix the problem was discussed here https://github.com/bucketeer-io/android-client-sdk/pull/88#discussion_r1333847962