### PR TITLE
fix: missing timeout value in the timeout error event

### DIFF
--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -92,7 +92,6 @@ final class ApiClientImpl: ApiClient {
             return keys.last ?? keys[0]
         })
 
-        let timeoutMillisValue = defaultRequestTimeoutMills
         send(
             requestBody: requestBody,
             path: "register_events",
@@ -103,7 +102,7 @@ final class ApiClientImpl: ApiClient {
                 case .success((let response, _)):
                     completion?(.success(response))
                 case .failure(let error):
-                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: timeoutMillisValue)))
+                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: defaultRequestTimeoutMills)))
                 }
             }
         )

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -92,6 +92,7 @@ final class ApiClientImpl: ApiClient {
             return keys.last ?? keys[0]
         })
 
+        let timeoutMillisValue = defaultRequestTimeoutMills
         send(
             requestBody: requestBody,
             path: "register_events",
@@ -102,7 +103,7 @@ final class ApiClientImpl: ApiClient {
                 case .success((let response, _)):
                     completion?(.success(response))
                 case .failure(let error):
-                    completion?(.failure(.init(error: error)))
+                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: timeoutMillisValue)))
                 }
             }
         )

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -92,18 +92,17 @@ final class ApiClientImpl: ApiClient {
             return keys.last ?? keys[0]
         })
 
-        let timeoutMillisValue = defaultRequestTimeoutMills
         send(
             requestBody: requestBody,
             path: "register_events",
             timeoutMillis: defaultRequestTimeoutMills,
             encoder: encoder,
-            completion: { (result: Result<(RegisterEventsResponse, URLResponse), Error>) in
+            completion: { [self] (result: Result<(RegisterEventsResponse, URLResponse), Error>) in
                 switch result {
                 case .success((let response, _)):
                     completion?(.success(response))
                 case .failure(let error):
-                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: timeoutMillisValue)))
+                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: defaultRequestTimeoutMills)))
                 }
             }
         )

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -92,6 +92,7 @@ final class ApiClientImpl: ApiClient {
             return keys.last ?? keys[0]
         })
 
+        let timeoutMillisValue = defaultRequestTimeoutMills
         send(
             requestBody: requestBody,
             path: "register_events",
@@ -102,7 +103,7 @@ final class ApiClientImpl: ApiClient {
                 case .success((let response, _)):
                     completion?(.success(response))
                 case .failure(let error):
-                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: defaultRequestTimeoutMills)))
+                    completion?(.failure(.init(error: error).copyWith(timeoutMillis: timeoutMillisValue)))
                 }
             }
         )


### PR DESCRIPTION
- The register event request could throw the timeout exception, but we are missing to log the timeout value
- This is small changes to make the timeout error metrics event always has timeout value 