### PR TITLE
ci: change how swiftlint is managed

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,6 +21,22 @@ jobs:
         with:
           args: --strict
 
+  install-mint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: make install-mint
+
+  bootstrap-mint:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: make bootstrap-mint
+
   lint_pod:
     runs-on: macos-latest
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -70,24 +70,16 @@ jobs:
 
   build:
     runs-on: macos-latest
-    needs: install-mint
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Mint packages
-        uses: actions/cache@v3
-        with:
-          path: .mint
-          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-          restore-keys: |
-            ${{ runner.os }}-mint-
-
       - name: Build
+        env:
+          CI: true
         run: make build
 
   build-example:
     runs-on: macos-latest
-    needs: install-mint
     steps:
       - uses: actions/checkout@v3
 
@@ -96,32 +88,19 @@ jobs:
           CI: true
         run: make environment-setup
 
-      - name: Cache Mint packages
-        uses: actions/cache@v3
-        with:
-          path: .mint
-          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-          restore-keys: |
-            ${{ runner.os }}-mint-
-
       - name: Build example
+        env:
+          CI: true
         run: make build-example
 
   test:
     runs-on: macos-latest
-    needs: install-mint
     steps:
       - uses: actions/checkout@v3
 
-      - name: Cache Mint packages
-        uses: actions/cache@v3
-        with:
-          path: .mint
-          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
-          restore-keys: |
-            ${{ runner.os }}-mint-
-
       - name: Build for testing
+        env:
+          CI: true
         run: make build-for-testing
 
       - name: Unit Test

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,27 +19,46 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Install mint
-        run: make install-mint
+        run: |
+          brew install mint
 
-  bootstrap-mint:
-    runs-on: macos-latest
-    needs: install-mint
-    steps:
-      - uses: actions/checkout@v3
+      - name: restore Mint packages
+        id: cache-restore
+        uses: actions/cache/restore@v3
+        with:
+            path: .mint
+            key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
 
       - name: Bootstrap mint
         env:
           CI: true
-
         run: make bootstrap-mint
 
+      - name: Cache Mint packages
+        uses: actions/cache@v3
+        with:
+          path: .mint
+          key: ${{ steps.cache-restore.outputs.cache-primary-key }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
   lint_swift:
-    needs: bootstrap-mint
+    needs: install-mint
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 
+      - name: Cache Mint packages
+        uses: actions/cache@v3
+        with:
+          path: .mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
       - name: Lint swift
+        env:
+          CI: true
         run: make run-lint
 
   lint_pod:
@@ -51,16 +70,24 @@ jobs:
 
   build:
     runs-on: macos-latest
-    needs: bootstrap-mint
+    needs: install-mint
     steps:
       - uses: actions/checkout@v3
+
+      - name: Cache Mint packages
+        uses: actions/cache@v3
+        with:
+          path: .mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
 
       - name: Build
         run: make build
 
   build-example:
     runs-on: macos-latest
-    needs: bootstrap-mint
+    needs: install-mint
     steps:
       - uses: actions/checkout@v3
 
@@ -69,14 +96,30 @@ jobs:
           CI: true
         run: make environment-setup
 
+      - name: Cache Mint packages
+        uses: actions/cache@v3
+        with:
+          path: .mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
+
       - name: Build example
         run: make build-example
 
   test:
     runs-on: macos-latest
-    needs: bootstrap-mint
+    needs: install-mint
     steps:
       - uses: actions/checkout@v3
+
+      - name: Cache Mint packages
+        uses: actions/cache@v3
+        with:
+          path: .mint
+          key: ${{ runner.os }}-mint-${{ hashFiles('**/Mintfile') }}
+          restore-keys: |
+            ${{ runner.os }}-mint-
 
       - name: Build for testing
         run: make build-for-testing

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,23 +18,28 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build
+      - name: Install mint
         run: make install-mint
 
   bootstrap-mint:
     runs-on: macos-latest
+    needs: install-mint
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build
+      - name: Bootstrap mint
+        env:
+          CI: true
+
         run: make bootstrap-mint
 
   lint_swift:
+    needs: bootstrap-mint
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 
-      - name: Build
+      - name: Lint swift
         run: make run-lint
 
   lint_pod:
@@ -46,6 +51,7 @@ jobs:
 
   build:
     runs-on: macos-latest
+    needs: bootstrap-mint
     steps:
       - uses: actions/checkout@v3
 
@@ -54,6 +60,7 @@ jobs:
 
   build-example:
     runs-on: macos-latest
+    needs: bootstrap-mint
     steps:
       - uses: actions/checkout@v3
 
@@ -67,6 +74,7 @@ jobs:
 
   test:
     runs-on: macos-latest
+    needs: bootstrap-mint
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,14 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: norio-nomura/action-swiftlint@9f4dcd7fd46b4e75d7935cf2f4df406d5cae3684 # v3.2.1
-        with:
-          args: --strict
-
   install-mint:
     runs-on: macos-latest
     steps:
@@ -36,6 +28,14 @@ jobs:
 
       - name: Build
         run: make bootstrap-mint
+
+  lint_swift:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Build
+        run: make run-lint
 
   lint_pod:
     runs-on: macos-latest

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ fastlane/.env
 
 # proto
 proto_output
+
+# mint
+mint/

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -10,13 +10,17 @@ disabled_rules: # rule identifiers turned on by default to exclude from running
 
 opt_in_rules:
   - let_var_whitespace
-  - unused_declaration
-  - unused_import
   - vertical_whitespace_closing_braces
 
+analyzer_rules:
+  - unused_declaration
+  - unused_import
+  
 excluded:
   - Example
   - ExampleTVOS
+  - DerivedData
+
 
 allow_zero_lintable_files: false
 
@@ -37,7 +41,7 @@ type_name:
   max_length:
     warning: 40
     error: 50
-  excluded: 
+  excluded:
     - iPhone
     - DB
   allowed_symbols: ["_"]

--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -1072,7 +1072,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\n# Mintでrswiftを実行\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
+			shellScript = "#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -839,6 +839,7 @@
 				0065C3BA28C7BB76002D92A2 /* Sources */,
 				0065C3BB28C7BB76002D92A2 /* Frameworks */,
 				0065C3BC28C7BB76002D92A2 /* Resources */,
+				9BC3E3082AE91D7700849EB8 /* Run Script(linter) */,
 			);
 			buildRules = (
 			);
@@ -1053,6 +1054,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		9BC3E3082AE91D7700849EB8 /* Run Script(linter) */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script(linter)";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "make run-lint\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		0065C3BA28C7BB76002D92A2 /* Sources */ = {

--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -1072,7 +1072,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
+			shellScript = "#Run this script if not in a CI environment.\nif [ -n $CI ] && [ $CI = \"true\" ]; then\n  echo \"Run this script if not in a CI environment.\"\n  exit 0\nfi\n\n#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -1072,7 +1072,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "make run-lint\n";
+			shellScript = "#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\n# Mintでrswiftを実行\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -1072,7 +1072,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#Run this script if not in a CI environment.\nif [ -n $CI ] && [ $CI = \"true\" ]; then\n  echo \"Run this script if not in a CI environment.\"\n  exit 0\nfi\n\n#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is installed. Please run make install-mint.\"\nfi\n";
+			shellScript = "#Run this script if not in a CI environment.\nif [ -n $CI ] && [ $CI = \"true\" ]; then\n  echo \"Run this script if not in a CI environment.\"\n  exit 0\nfi\n\n#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is not installed. Please run make install-mint.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Makefile
+++ b/Makefile
@@ -61,9 +61,6 @@ build:
 build-for-testing:
 	$(BUILD_FOR_TESTING)
 
-.PHONY: lint
-lint:
-	swiftlint --strict
 .PHONY: install-mint
 install-mint:
 	./hack/mint.sh --install
@@ -71,6 +68,10 @@ install-mint:
 .PHONY: bootstrap-mint
 bootstrap-mint:
 	./hack/mint.sh --bootstrap
+
+.PHONY: run-lint
+run-lint:
+	./hack/lint.sh --run
 
 .PHONY: test-without-building
 test-without-building:

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,13 @@ build-for-testing:
 .PHONY: lint
 lint:
 	swiftlint --strict
+.PHONY: install-mint
+install-mint:
+	./hack/mint.sh --install
+
+.PHONY: bootstrap-mint
+bootstrap-mint:
+	./hack/mint.sh --bootstrap
 
 .PHONY: test-without-building
 test-without-building:

--- a/Mintfile
+++ b/Mintfile
@@ -1,0 +1,1 @@
+realm/SwiftLint@0.53.0

--- a/README.md
+++ b/README.md
@@ -34,6 +34,20 @@ Please follow our contribution guide [here](https://docs.bucketeer.io/contributi
 
 ## Development
 
+### Setup the library management
+This　project use [mint](https://github.com/yonaskolb/Mint) for library management.
+
+#### Install
+```sh
+make install-mint
+```
+※You need [homebrew](https://brew.sh/) to install mint.
+
+#### Install library
+```sh
+make bootstrap-mint
+```
+
 ### Setup the environment xcconfig file
 
 Execute the following Makefile to create the environment xcconfig file.<br />

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -3,16 +3,14 @@
 source ./hack/mint.sh
 
 function run() {
-    PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
-    echo "PROJECT_DIR=$PROJECT_DIR"
+    command_output=$(mint which swiftlint 2>&1)
+    exit_status=$?
 
-    SWIFTLINT_FILE_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL/swiftlint"
-
-    if [ ! -e $SWIFTLINT_FILE_PATH ]; then
-        echo "swiftlint: not found."
+    if [ $exit_status -ne 0 ]; then
+        echo "swiftlint not found. $command_output"
         mint_bootstrap
     fi
-    $SWIFTLINT_FILE_PATH
+    mint run swiftlint --strict
 }
 
 if [ ${#@} -eq 1 ]; then

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -3,12 +3,20 @@
 source ./hack/mint.sh
 
 function run() {
+    if [ "$CI" = "" ]; then
+        export MINT_LINK_PATH="$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH="$MINT_LIBRARY_PATH_AT_INSTALL"
+    else
+        export MINT_LINK_PATH=".$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH=".$MINT_LIBRARY_PATH_AT_INSTALL"
+    fi
+    
     command_output=$(mint which swiftlint 2>&1)
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
         echo "swiftlint not found. $command_output"
-        mint_bootstrap
+        bootstrap_mint
     fi
     mint run swiftlint --strict
 }

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -15,7 +15,7 @@ function run() {
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
-        echo "swiftlint not found. $command_output"
+        echo "SwiftLint didn't find. $command_output"
         bootstrap_mint
     fi
     mint run swiftlint --strict

--- a/hack/lint.sh
+++ b/hack/lint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+source ./hack/mint.sh
+
+function run() {
+    PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
+    echo "PROJECT_DIR=$PROJECT_DIR"
+
+    SWIFTLINT_FILE_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL/swiftlint"
+
+    if [ ! -e $SWIFTLINT_FILE_PATH ]; then
+        echo "swiftlint: not found."
+        mint_bootstrap
+    fi
+    $SWIFTLINT_FILE_PATH
+}
+
+if [ ${#@} -eq 1 ]; then
+    if [ "${@#"-r"}" = "" ] || [ "${@#"--run"}" = "" ]; then
+        run
+    fi
+fi

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -12,11 +12,19 @@ function bootstrap_mint() {
         export MINT_PATH=".$MINT_LIBRARY_PATH_AT_INSTALL"
     fi
 
+    result_search_mint=$(brew list | grep mint 2>&1)
+    exit_status=$?
+
+    if [ $exit_status -ne 0 ] || [result_search_mint=""]; then
+        echo "mint doesn't install. $command_output"
+        install_mint
+    fi
+
     command_output=$(mint bootstrap --link --overwrite y 2>&1)
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
-        echo "mint bootstrap was error. Please make install-mint. $command_output"
+        echo "mint bootstrap was error. $command_output"
         exit 1
     fi
 }

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+MINT_LINK_PATH_AT_INSTALL="mint/bin"
+
+function bootstrap_mint() {
+    PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
+    echo "PROJECT_DIR=$PROJECT_DIR"
+
+    export MINT_LINK_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL"
+
+    command_output=$(mint bootstrap -l --overwrite y 2>&1)
+    exit_status=$?
+    if [ $exit_status -ne 0 ]; then
+       echo "mint bootstrap was error. Please make install-mint. $command_output"
+       exit 1
+    fi
+}
+
+function install_mint()  {
+    brew install mint
+}
+
+if [ ${#@} -eq 1 ]; then
+    if [ "${@#"-b"}" = "" ] || [ "${@#"--bootstrap"}" = "" ]; then
+        bootstrap_mint
+    fi
+    if [ "${@#"-i"}" = "" ] || [ "${@#"--install"}" = "" ]; then
+        install_mint
+    fi
+fi

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -3,13 +3,14 @@
 MINT_LINK_PATH_AT_INSTALL="mint/bin"
 
 function bootstrap_mint() {
-    PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
-    echo "PROJECT_DIR=$PROJECT_DIR"
+    if [ "$CI" = "" ]; then
+        PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
+        export MINT_LINK_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL"
+    fi
 
-    export MINT_LINK_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL"
-
-    command_output=$(mint bootstrap -l --overwrite y 2>&1)
+    command_output=$(mint bootstrap --link --overwrite y 2>&1)
     exit_status=$?
+
     if [ $exit_status -ne 0 ]; then
        echo "mint bootstrap was error. Please make install-mint. $command_output"
        exit 1

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -15,7 +15,7 @@ function bootstrap_mint() {
     result_search_mint=$(brew list | grep mint 2>&1)
     exit_status=$?
 
-    if [ $exit_status -ne 0 ] || [result_search_mint=""]; then
+    if [ $exit_status -ne 0 ] || [ $result_search_mint = "" ]; then
         echo "mint doesn't install. $command_output"
         install_mint
     fi

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -16,7 +16,7 @@ function bootstrap_mint() {
     exit_status=$?
 
     if [ $exit_status -ne 0 ] || [ $result_search_mint = "" ]; then
-        echo "mint doesn't install. $command_output"
+        echo "Mint is not installed. $command_output"
         install_mint
     fi
 
@@ -24,7 +24,7 @@ function bootstrap_mint() {
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
-        echo "mint bootstrap was error. $command_output"
+        echo "Mint bootstrap has failed. $command_output"
         exit 1
     fi
 }

--- a/hack/mint.sh
+++ b/hack/mint.sh
@@ -1,19 +1,23 @@
 #!/bin/bash
 
+MINT_LIBRARY_PATH_AT_INSTALL="mint/lib"
 MINT_LINK_PATH_AT_INSTALL="mint/bin"
 
 function bootstrap_mint() {
     if [ "$CI" = "" ]; then
-        PROJECT_DIR=$(xcodebuild -showBuildSettings | grep "PROJECT_DIR = .*" | sed "s/PROJECT_DIR = //g" | sed "s/ //g")
-        export MINT_LINK_PATH="$PROJECT_DIR/$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_LINK_PATH="$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH="$MINT_LIBRARY_PATH_AT_INSTALL"
+    else
+        export MINT_LINK_PATH=".$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH=".$MINT_LIBRARY_PATH_AT_INSTALL"
     fi
 
     command_output=$(mint bootstrap --link --overwrite y 2>&1)
     exit_status=$?
 
     if [ $exit_status -ne 0 ]; then
-       echo "mint bootstrap was error. Please make install-mint. $command_output"
-       exit 1
+        echo "mint bootstrap was error. Please make install-mint. $command_output"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
swiftlint can be run on a local PC or CI, but the versions are not unified. Therefore, an error may occur on CI even if static analysis is successful on the local PC.

# Changes
- [x] swiftlint uses mint to manage versions.  
- [x] Create a command to install or run "swiftlint" and run the same command on your local PC or CI.
- [x] Add it to run at build time to run swiftlint continuously during development.