### PR TITLE
build: change Swiftlint not running when Carthage builds

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -1075,7 +1075,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#Run this script if not in a CI environment.\nif [ -n $CI ] && [ $CI = \"true\" ]; then\n  echo \"Run this script if not in a CI environment.\"\n  exit 0\nfi\n\n#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is not installed. Please run make install-mint.\"\nfi\n";
+			shellScript = "#Run this script if not in a CI environment or Carthage build.\nif [ -n $CI ] && [ \"$CI\" = \"true\" ]; then\n  echo \"Run this script if not in a CI environment.\"\n  exit 0\nelif [ -n \"$CARTHAGE\" ]; then\n  echo \"Run this script if not in Carthage build.\"\n  exit 0\nfi\n\n#Workaround: Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is not installed. Please run make install-mint.\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
As a result of changing Swiftlint to run at build time, an error occurs when building with Carthage on the main branch.

The cause is that Swiftlint is executed when building with Carthage.


# Changes
- [x]  Change Swiftlint not running when Carthage builds.
