### PR TITLE
test: fix build for E2E test

### DIFF
--- a/Bucketeer.xcodeproj/project.pbxproj
+++ b/Bucketeer.xcodeproj/project.pbxproj
@@ -91,8 +91,8 @@
 		9340CA0928D9D1DD00E690CC /* EvaluationStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA0828D9D1DD00E690CC /* EvaluationStorageTests.swift */; };
 		9340CA1928DA0F6200E690CC /* EventSQLDao.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1628DA0F6200E690CC /* EventSQLDao.swift */; };
 		9340CA1A28DA0F6200E690CC /* EventEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1728DA0F6200E690CC /* EventEntity.swift */; };
-		9340CA1B28DA0F6200E690CC /* EventDaoSQLImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1828DA0F6200E690CC /* EventDaoSQLImpl.swift */; };
-		9340CA1F28DA106200E690CC /* EventDaoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1E28DA106200E690CC /* EventDaoTests.swift */; };
+		9340CA1B28DA0F6200E690CC /* EventSQLDaoImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1828DA0F6200E690CC /* EventSQLDaoImpl.swift */; };
+		9340CA1F28DA106200E690CC /* EventSQLDaoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA1E28DA106200E690CC /* EventSQLDaoTests.swift */; };
 		9340CA2C28DAEA1500E690CC /* MigrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA2B28DAEA1500E690CC /* MigrationTests.swift */; };
 		9340CA5928E1CD2600E690CC /* UserHolder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA5828E1CD2600E690CC /* UserHolder.swift */; };
 		9340CA5B28E1CE7200E690CC /* BKTUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9340CA5A28E1CE7200E690CC /* BKTUser.swift */; };
@@ -301,8 +301,8 @@
 		9340CA0828D9D1DD00E690CC /* EvaluationStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EvaluationStorageTests.swift; sourceTree = "<group>"; };
 		9340CA1628DA0F6200E690CC /* EventSQLDao.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSQLDao.swift; sourceTree = "<group>"; };
 		9340CA1728DA0F6200E690CC /* EventEntity.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventEntity.swift; sourceTree = "<group>"; };
-		9340CA1828DA0F6200E690CC /* EventDaoSQLImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventDaoSQLImpl.swift; sourceTree = "<group>"; };
-		9340CA1E28DA106200E690CC /* EventDaoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventDaoTests.swift; sourceTree = "<group>"; };
+		9340CA1828DA0F6200E690CC /* EventSQLDaoImpl.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = EventSQLDaoImpl.swift; sourceTree = "<group>"; };
+		9340CA1E28DA106200E690CC /* EventSQLDaoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventSQLDaoTests.swift; sourceTree = "<group>"; };
 		9340CA2B28DAEA1500E690CC /* MigrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MigrationTests.swift; sourceTree = "<group>"; };
 		9340CA5828E1CD2600E690CC /* UserHolder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserHolder.swift; sourceTree = "<group>"; };
 		9340CA5A28E1CE7200E690CC /* BKTUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BKTUser.swift; sourceTree = "<group>"; };
@@ -455,7 +455,7 @@
 				934889C628EB0ADB007BA05C /* EvaluationForegroundTaskTests.swift */,
 				006E85C228DED24500B5D90D /* EvaluationInteractorTests.swift */,
 				935D9AAF28F5B0DB007775F5 /* EvaluationTests.swift */,
-				9340CA1E28DA106200E690CC /* EventDaoTests.swift */,
+				9340CA1E28DA106200E690CC /* EventSQLDaoTests.swift */,
 				937DE95F28E498DF00743FDB /* EventForegroundTaskTests.swift */,
 				006E85DD28E032E800B5D90D /* EventInteractorTests.swift */,
 				0065C3F828C81A0D002D92A2 /* JSONDecodingTests.swift */,
@@ -699,7 +699,7 @@
 			isa = PBXGroup;
 			children = (
 				9340CA1628DA0F6200E690CC /* EventSQLDao.swift */,
-				9340CA1828DA0F6200E690CC /* EventDaoSQLImpl.swift */,
+				9340CA1828DA0F6200E690CC /* EventSQLDaoImpl.swift */,
 				9340CA1728DA0F6200E690CC /* EventEntity.swift */,
 				006E85CD28DEE23100B5D90D /* EventInteractor.swift */,
 			);
@@ -1118,7 +1118,7 @@
 				0065C3E328C8136D002D92A2 /* Event.swift in Sources */,
 				004CF1F32929C9E500CCC3DF /* EventBackgroundTask.swift in Sources */,
 				9340CA1928DA0F6200E690CC /* EventSQLDao.swift in Sources */,
-				9340CA1B28DA0F6200E690CC /* EventDaoSQLImpl.swift in Sources */,
+				9340CA1B28DA0F6200E690CC /* EventSQLDaoImpl.swift in Sources */,
 				946540372A821A11009BF89F /* EvaluationMemCacheDao.swift in Sources */,
 				0065C3E528C813D6002D92A2 /* EventData.swift in Sources */,
 				9340CA1A28DA0F6200E690CC /* EventEntity.swift in Sources */,
@@ -1175,7 +1175,7 @@
 				934889C728EB0ADB007BA05C /* EvaluationForegroundTaskTests.swift in Sources */,
 				006E85C328DED24500B5D90D /* EvaluationInteractorTests.swift in Sources */,
 				935D9AB028F5B0DB007775F5 /* EvaluationTests.swift in Sources */,
-				9340CA1F28DA106200E690CC /* EventDaoTests.swift in Sources */,
+				9340CA1F28DA106200E690CC /* EventSQLDaoTests.swift in Sources */,
 				937DE96028E498E000743FDB /* EventForegroundTaskTests.swift in Sources */,
 				006E85DE28E032E800B5D90D /* EventInteractorTests.swift in Sources */,
 				0065C3F928C81A0D002D92A2 /* JSONDecodingTests.swift in Sources */,

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -32,7 +32,7 @@ final class ComponentImpl: Component {
             device: dataModule.device,
             eventsMaxBatchQueueCount: dataModule.config.eventsMaxQueueSize,
             apiClient: dataModule.apiClient,
-            eventDao: dataModule.eventSQLDao,
+            eventSQLDao: dataModule.eventSQLDao,
             clock: dataModule.clock,
             idGenerator: dataModule.idGenerator,
             logger: dataModule.config.logger,

--- a/Bucketeer/Sources/Internal/DI/DataModule.swift
+++ b/Bucketeer/Sources/Internal/DI/DataModule.swift
@@ -24,7 +24,7 @@ final class DataModuleImpl: DataModule {
         self.config = config
         self.sqlite = try DatabaseOpenHelper.createDatabase(logger: config.logger)
         self.evaluationDao = EvaluationSQLDaoImpl(db: sqlite)
-        self.eventSQLDao = EventDaoSQLImpl(db: sqlite)
+        self.eventSQLDao = EventSQLDaoImpl(db: sqlite)
     }
 
     private(set) lazy var clock: Clock = ClockImpl()

--- a/Bucketeer/Sources/Internal/Event/EventSQLDaoImpl.swift
+++ b/Bucketeer/Sources/Internal/Event/EventSQLDaoImpl.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-final class EventDaoSQLImpl: EventSQLDao {
+final class EventSQLDaoImpl: EventSQLDao {
     private let db: SQLite
 
     init(db: SQLite) {

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -59,7 +59,7 @@ final class E2EEventTests: XCTestCase {
 
             // getVariationValue() is logging events using another dispatch queue, we need to wait a few secs
             try await Task.sleep(nanoseconds: 10_000_000)
-            let events = try component.dataModule.eventDao.getEvents()
+            let events = try component.dataModule.eventSQLDao.getEvents()
             // It includes the Latency and ResponseSize metrics
             XCTAssertEqual(events.count, 7)
             XCTAssertTrue(events.contains { event in
@@ -73,7 +73,7 @@ final class E2EEventTests: XCTestCase {
 
             try await client.flush()
 
-            XCTAssertEqual(try component.dataModule.eventDao.getEvents().count, 0)
+            XCTAssertEqual(try component.dataModule.eventSQLDao.getEvents().count, 0)
         } catch {
             XCTFail(error.localizedDescription)
         }
@@ -110,7 +110,7 @@ final class E2EEventTests: XCTestCase {
 
             // getVariationValue() is logging events using another dispatch queue, we need to wait a few secs
             try await Task.sleep(nanoseconds: 10_000_000)
-            let events = try component.dataModule.eventDao.getEvents()
+            let events = try component.dataModule.eventSQLDao.getEvents()
             // It includes the Latency and ResponseSize metrics
             XCTAssertEqual(events.count, 7)
             XCTAssertTrue(events.contains { event in
@@ -124,7 +124,7 @@ final class E2EEventTests: XCTestCase {
 
             try await client.flush()
 
-            XCTAssertEqual(try component.dataModule.eventDao.getEvents().count, 0)
+            XCTAssertEqual(try component.dataModule.eventSQLDao.getEvents().count, 0)
         } catch {
             XCTFail(error.localizedDescription)
         }

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -86,11 +86,10 @@ final class E2EEventTests: XCTestCase {
                 XCTFail("could not access client.component")
                 return
             }
-            let userId = client.component.userHolder.userId
             try await withCheckedThrowingContinuation({ continuation in
                 client.execute {
                     do {
-                        try component.dataModule.evaluationStorage.deleteAllAndInsert(userId: userId, evaluations: [], evaluatedAt: "0")
+                        try component.dataModule.evaluationStorage.deleteAllAndInsert(evaluationId: "evaluationId", evaluations: [], evaluatedAt: "0")
                         continuation.resume(returning: ())
                     } catch {
                         continuation.resume(throwing: error)

--- a/BucketeerTests/E2E/E2EMetricsEventTests.swift
+++ b/BucketeerTests/E2E/E2EMetricsEventTests.swift
@@ -49,7 +49,7 @@ final class E2EMetricsEventTests: XCTestCase {
             XCTFail("could not access client.component")
             return
         }
-        let events : [Event] = try component.dataModule.eventDao.getEvents()
+        let events : [Event] = try component.dataModule.eventSQLDao.getEvents()
         // It includes the Latency and ResponseSize metrics
         XCTAssertEqual(events.count, 1)
         XCTAssertTrue(events.contains { event in
@@ -73,7 +73,7 @@ final class E2EMetricsEventTests: XCTestCase {
             }
         }
 
-        let events2 : [Event] = try component.dataModule.eventDao.getEvents()
+        let events2 : [Event] = try component.dataModule.eventSQLDao.getEvents()
         // It includes the Latency and ResponseSize metrics
         XCTAssertEqual(events2.count, 2)
     }
@@ -114,7 +114,7 @@ final class E2EMetricsEventTests: XCTestCase {
             XCTFail("could not access client.component")
             return
         }
-        let events : [Event] = try component.dataModule.eventDao.getEvents()
+        let events : [Event] = try component.dataModule.eventSQLDao.getEvents()
         XCTAssertEqual(events.count, 1)
         XCTAssertTrue(events.contains { event in
             if case .metrics = event.type,
@@ -129,6 +129,6 @@ final class E2EMetricsEventTests: XCTestCase {
 
         try await client.flush()
 
-        XCTAssertEqual(try component.dataModule.eventDao.getEvents().count, 0)
+        XCTAssertEqual(try component.dataModule.eventSQLDao.getEvents().count, 0)
     }
 }

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -16,7 +16,7 @@ final class EventInteractorTests: XCTestCase {
             device: MockDevice(),
             eventsMaxBatchQueueCount: 3,
             apiClient: api,
-            eventDao: dao,
+            eventSQLDao: dao,
             clock: clock,
             idGenerator: idGenerator,
             logger: logger,

--- a/BucketeerTests/EventSQLDaoTests.swift
+++ b/BucketeerTests/EventSQLDaoTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import Bucketeer
 
 @available(iOS 13, *)
-final class EventDaoTests: XCTestCase {
+final class EventSQLDaoTests: XCTestCase {
     let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("event_test.db")
     var path: String { url.path }
 
@@ -23,7 +23,7 @@ final class EventDaoTests: XCTestCase {
 
     func testAddEventGoal() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
 
         try dao.add(event: .mockGoal1)
 
@@ -45,7 +45,7 @@ final class EventDaoTests: XCTestCase {
 
     func testAddEventEvaluation() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
 
         try dao.add(event: .mockEvaluation1)
 
@@ -67,7 +67,7 @@ final class EventDaoTests: XCTestCase {
 
     func testAddEventMetrics() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
 
         try dao.add(event: .mockMetricsResponseLatency1)
 
@@ -89,7 +89,7 @@ final class EventDaoTests: XCTestCase {
 
     func testAddEvents() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
 
         try dao.add(events: [.mockGoal1, .mockEvaluation1, .mockMetricsResponseLatency1, .mockEvaluation2])
 
@@ -103,7 +103,7 @@ final class EventDaoTests: XCTestCase {
 
     func testDeleteAll() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
         let target: [Event] = [.mockGoal1, .mockEvaluation1, .mockMetricsResponseLatency1, .mockEvaluation2]
         try dao.add(events: target)
 
@@ -116,7 +116,7 @@ final class EventDaoTests: XCTestCase {
 
     func testDeleteSomeItems() throws {
         let db = try SQLite(path: path, logger: nil)
-        let dao = EventDaoSQLImpl(db: db)
+        let dao = EventSQLDaoImpl(db: db)
         let target: [Event] = [.mockGoal1, .mockEvaluation1, .mockMetricsResponseLatency1, .mockEvaluation2]
         try dao.add(events: target)
 


### PR DESCRIPTION
A build error occurred related to [E2ETest](https://github.com/bucketeer-io/ios-client-sdk/actions/runs/6887151181/job/18733901932#step:3:1210).

example:
/ios-client-sdk/BucketeerTests/E2E/E2EEventTests.swift:62:51

```
error: value of type 'any DataModule' has no member 'eventDao'
            let events = try component.dataModule.eventDao.getEvents()
```


This seems to be caused by https://github.com/bucketeer-io/ios-client-sdk/pull/51 not considering the response to https://github.com/bucketeer-io/ios-client-sdk/pull/49.

# Changes

- [x] unify `EventDao` to `EventSQLDao`
- [x] fix build error for `testDefaultEvaluationEvents()`