### PR TITLE
ci: upload xcframework file error

### DIFF
--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -33,24 +33,19 @@ jobs:
             make generate-project-file
             make create-xcframework-zip
 
-      - name: output xcframework file
+      - name: Save xcframework file
         uses: actions/upload-artifact@v3
         with:
           name: output-xcframework-file
           path: ./FrameworkBuild/Bucketeer.xcframework.zip
-    
+
   upload-xcframework:
     needs: create-xcframework
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: google-github-actions/release-please-action@51ee8ae2605bd5ce1cfdcc5938684908f1cd9f69 # v3.7.9
-        id: release
-        with:
-          token: ${{ secrets.WORKFLOW_TOKEN }}
-          release-type: node
 
-      - name: Download xcframework file
+      - name: Get xcframework file
         uses: actions/download-artifact@v3
         with:
           name: output-xcframework-file
@@ -59,4 +54,4 @@ jobs:
       - name: Upload Release Framework
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ steps.release.outputs.tag_name }} ./FrameworkBuild/Bucketeer.xcframework.zip
+        run: gh release upload ${GITHUB_REF#refs/*/} ./FrameworkBuild/Bucketeer.xcframework.zip

--- a/hack/create-xcframework.sh
+++ b/hack/create-xcframework.sh
@@ -16,6 +16,7 @@ function create_xcframework() {
 if [ ${#@} -eq 1 ]; then
   create_xcframework
   if [ "${@#"-z"}" = "" ] || [ "${@#"--zip"}" = "" ]; then
-    zip FrameworkBuild/Bucketeer.xcframework.zip FrameworkBuild/Bucketeer.xcframework
+    cd FrameworkBuild
+    zip -r Bucketeer.xcframework.zip Bucketeer.xcframework
   fi
 fi


### PR DESCRIPTION
- There is an unnecessary step when uploading xcframework file, which causes an [error](https://github.com/bucketeer-io/ios-client-sdk/actions/runs/7335283274), so I deleted it.
- The top directory of the xcframework zip file was `FrameworkBuild`, so fixed it to exclude it. 
