### PR TITLE
chore: update error metrics report

### DIFF
--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -382,7 +382,21 @@ extension BKTError {
         case .illegalArgument, .illegalState:
             metricsEventData = .internalSdkError(.init(apiId: apiId, labels: labels))
             metricsEventType = .internalError
-        case .unknownServer, .unknown:
+        case .unknownServer(let message, _, let statusCode):
+            metricsEventData = .unknownError(
+                .init(
+                    apiId: apiId,
+                    labels: labels.merging(
+                        [
+                            "error_message":message,
+                            "response_status_code":"\(statusCode)"
+                        ]
+                        , uniquingKeysWith: { (first, _) in first }
+                    )
+                )
+            )
+            metricsEventType = .unknownError
+        case .unknown:
             metricsEventData = .unknownError(.init(apiId: apiId, labels: labels))
             metricsEventType = .unknownError
         }

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -352,8 +352,8 @@ extension BKTError {
             metricsEventType = .timeoutError
         case .payloadTooLarge:
             metricsEventData = .payloadTooLarge(.init(apiId: apiId, labels: labels))
-            metricsEventType = .networkError
-        case .redirectRequest(let message, let statusCode):
+            metricsEventType = .payloadTooLarge
+        case .redirectRequest(_, let statusCode):
             metricsEventData = .redirectRequest(
                 .init(
                     apiId: apiId,
@@ -365,7 +365,7 @@ extension BKTError {
                     )
                 )
             )
-            metricsEventType = .badRequestError
+            metricsEventType = .redirectRequest
         case .network:
             metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
             metricsEventType = .networkError

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -319,6 +319,10 @@ extension Event {
                 return mp.uniqueKey()
             case .unknownError(let mp):
                 return mp.uniqueKey()
+            case .redirectRequest(let mp):
+                return mp.uniqueKey()
+            case .payloadTooLarge(let mp):
+                return mp.uniqueKey()
             }
         default: return id
         }
@@ -346,14 +350,21 @@ extension BKTError {
                 )
             )
             metricsEventType = .timeoutError
-        case .invalidHttpMethod:
-            metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
-            metricsEventType = .networkError
         case .payloadTooLarge:
-            metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+            metricsEventData = .payloadTooLarge(.init(apiId: apiId, labels: labels))
             metricsEventType = .networkError
-        case .redirectRequest:
-            metricsEventData = .badRequestError(.init(apiId: apiId, labels: labels))
+        case .redirectRequest(let message, let statusCode):
+            metricsEventData = .redirectRequest(
+                .init(
+                    apiId: apiId,
+                    labels: labels.merging(
+                        [
+                            "response_code":"\(statusCode)"
+                        ]
+                        , uniquingKeysWith: { (first, _) in first }
+                    )
+                )
+            )
             metricsEventType = .badRequestError
         case .network:
             metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
@@ -379,7 +390,7 @@ extension BKTError {
         case .apiServer:
             metricsEventData = .internalServerError(.init(apiId: apiId, labels: labels))
             metricsEventType = .internalServerError
-        case .illegalArgument, .illegalState:
+        case .illegalArgument, .illegalState, .invalidHttpMethod:
             metricsEventData = .internalSdkError(.init(apiId: apiId, labels: labels))
             metricsEventType = .internalError
         case .unknownServer(let message, _, let statusCode):
@@ -389,7 +400,7 @@ extension BKTError {
                     labels: labels.merging(
                         [
                             "error_message":message,
-                            "response_status_code":"\(statusCode)"
+                            "response_code":"\(statusCode)"
                         ]
                         , uniquingKeysWith: { (first, _) in first }
                     )

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -346,6 +346,9 @@ extension BKTError {
                 )
             )
             metricsEventType = .timeoutError
+        case .invalidHttpMethod:
+            metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .networkError
         case .payloadTooLarge:
             metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
             metricsEventType = .networkError

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -346,6 +346,12 @@ extension BKTError {
                 )
             )
             metricsEventType = .timeoutError
+        case .payloadTooLarge:
+            metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .networkError
+        case .redirectRequest:
+            metricsEventData = .badRequestError(.init(apiId: apiId, labels: labels))
+            metricsEventType = .badRequestError
         case .network:
             metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
             metricsEventType = .networkError

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -147,6 +147,10 @@ enum EventData: Hashable {
                 try container.encode(eventData, forKey: .event)
             case .unknownError(let eventData):
                 try container.encode(eventData, forKey: .event)
+            case .redirectRequest(let eventData):
+                try container.encode(eventData, forKey: .event)
+            case .payloadTooLarge(let eventData):
+                try container.encode(eventData, forKey: .event)
             }
             if let protobufType {
                 try container.encode(protobufType, forKey: .protobufType)

--- a/Bucketeer/Sources/Internal/Model/EventData.swift
+++ b/Bucketeer/Sources/Internal/Model/EventData.swift
@@ -105,6 +105,12 @@ enum EventData: Hashable {
             case .internalServerError:
                 let data = try container.decode(MetricsEventData.InternalServerError.self, forKey: .event)
                 self.event = .internalServerError(data)
+            case .redirectRequest:
+                let data = try container.decode(MetricsEventData.RedirectionRequestError.self, forKey: .event)
+                self.event = .redirectRequest(data)
+            case .payloadTooLarge:
+                let data = try container.decode(MetricsEventData.PayloadTooLargeError.self, forKey: .event)
+                self.event = .payloadTooLarge(data)
             case .unknownError:
                 let data = try container.decode(MetricsEventData.UnknownError.self, forKey: .event)
                 self.event = .unknownError(data)

--- a/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventData.swift
@@ -17,10 +17,12 @@ enum MetricsEventData: Hashable {
     case responseSize(ResponseSize)
     case timeoutError(TimeoutError)
     case networkError(NetworkError)
+    case redirectRequest(RedirectionRequestError)
     case badRequestError(BadRequestError)
     case unauthorizedError(UnauthorizedError)
     case forbiddenError(ForbiddenError)
     case notFoundError(NotFoundError)
+    case payloadTooLarge(PayloadTooLargeError)
     case clientClosedError(ClientClosedError)
     case unavailableError(UnavailableError)
     case internalSdkError(InternalSdkError)
@@ -151,10 +153,36 @@ enum MetricsEventData: Hashable {
         }
     }
 
+    // https://github.com/bucketeer-io/ios-client-sdk/issues/65
+    // The SDK will send the response code and the error message in the labels if possible
+    // E.g. {"response_code": "xxx", "error_message": "message"}
     struct UnknownError: Codable, Hashable, MetricsEventDataProps {
         let apiId: ApiId
         let labels: [String: String]
         var protobufType: String? = "type.googleapis.com/bucketeer.event.client.UnknownErrorMetricsEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
+    }
+
+    // RedirectionRequestError 3xx (301, 302 & 303)
+    // The SDK will send the response code in the labels
+    // E.g. {"response_code": "302"}
+    struct RedirectionRequestError: Codable, Hashable, MetricsEventDataProps {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.RedirectionRequestExceptionEvent"
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(apiId)
+        }
+    }
+
+    struct PayloadTooLargeError: Codable, Hashable, MetricsEventDataProps {
+        let apiId: ApiId
+        let labels: [String: String]
+        var protobufType: String? = "type.googleapis.com/bucketeer.event.client.PayloadTooLargeExceptionEvent"
 
         func hash(into hasher: inout Hasher) {
             hasher.combine(apiId)

--- a/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
+++ b/Bucketeer/Sources/Internal/Model/MetricsEventType.swift
@@ -14,4 +14,6 @@ enum MetricsEventType: Int, Codable, Hashable {
     case clientClosedError
     case unavailableError
     case internalServerError
+    case redirectRequest
+    case payloadTooLarge
 }

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -21,7 +21,7 @@ public enum BKTError: Error, Equatable {
     case illegalState(message: String)
 
     // unknown errors
-    case unknownServer(message: String, error: Error)
+    case unknownServer(message: String, error: Error, statusCode: Int)
     case unknown(message: String, error: Error)
 
     public static func == (lhs: BKTError, rhs: BKTError) -> Bool {
@@ -42,9 +42,10 @@ public enum BKTError: Error, Equatable {
         case (.timeout(let m1, _, let t1), .timeout(let m2, _, let t2)):
             return t1 == t2 && m1 == m2
         case (.network(let m1, _), .network(let m2, _)),
-             (.unknownServer(let m1, _), .unknownServer(let m2, _)),
              (.unknown(let m1, _), .unknown(let m2, _)):
             return m1 == m2
+        case (.unknownServer(let m1, _, let c1), .unknownServer(let m2, _, let c2)):
+            return m1 == m2 && c1 == c2
         default:
             return false
         }
@@ -92,7 +93,7 @@ extension BKTError : LocalizedError {
                     if let errorResponse = errorResponse {
                         message = "[\(errorResponse.error.code)] \(errorResponse.error.message)"
                     }
-                    self = .unknownServer(message: "Unknown server error: \(message)", error: error)
+                    self = .unknownServer(message: "Unknown server error: \(message)", error: error, statusCode: code)
                 }
             case .unknown(let urlResponse):
                 var message: String = "no response"
@@ -145,7 +146,7 @@ extension BKTError : LocalizedError {
             return message
         case .illegalState(message: let message):
             return message
-        case .unknownServer(message: let message, _):
+        case .unknownServer(message: let message, _, _):
             return message
         case .unknown(message: let message, _):
             return message
@@ -183,7 +184,7 @@ extension BKTError : LocalizedError {
         case .network(message: _, error: let error):
             return "\(error)"
 
-        case .unknownServer(message: _, error: let error):
+        case .unknownServer(message: _, error: let error, _):
             return "\(error)"
 
         case .unknown(message: _, error: let error):

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -8,7 +8,7 @@ public enum BKTError: Error, Equatable {
     case clientClosed(message: String)
     case unavailable(message: String)
     case apiServer(message: String)
-    case redirectRequest(message: String)
+    case redirectRequest(message: String, statusCode: Int)
     case payloadTooLarge(message: String)
     case invalidHttpMethod(message: String)
 
@@ -35,7 +35,6 @@ public enum BKTError: Error, Equatable {
              (.apiServer(let m1), .apiServer(let m2)),
              (.illegalArgument(let m1), .illegalArgument(let m2)),
              (.illegalState(let m1), .illegalState(let m2)),
-             (.redirectRequest(let m1), .redirectRequest(let m2)),
              (.payloadTooLarge(let m1), .payloadTooLarge(let m2)),
              (.invalidHttpMethod(let m1), .invalidHttpMethod(let m2)):
             return m1 == m2
@@ -45,6 +44,8 @@ public enum BKTError: Error, Equatable {
              (.unknown(let m1, _), .unknown(let m2, _)):
             return m1 == m2
         case (.unknownServer(let m1, _, let c1), .unknownServer(let m2, _, let c2)):
+            return m1 == m2 && c1 == c2
+        case (.redirectRequest(let m1, let c1), .redirectRequest(let m2, let c2)):
             return m1 == m2 && c1 == c2
         default:
             return false
@@ -67,7 +68,7 @@ extension BKTError : LocalizedError {
                 // Update error metrics report
                 // https://github.com/bucketeer-io/ios-client-sdk/issues/65
                 case 300..<400:
-                    self = .redirectRequest(message: errorResponse?.error.message ?? "RedirectRequest error")
+                    self = .redirectRequest(message: errorResponse?.error.message ?? "RedirectRequest error", statusCode: code)
                 case 400:
                     self = .badRequest(message: errorResponse?.error.message ?? "BadRequest error")
                 case 401:
@@ -150,7 +151,7 @@ extension BKTError : LocalizedError {
             return message
         case .unknown(message: let message, _):
             return message
-        case .redirectRequest(message: let message):
+        case .redirectRequest(message: let message, _):
             return message
         case .payloadTooLarge(message: let message):
             return message

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -77,9 +77,9 @@ extension BKTError : LocalizedError {
                 case 404:
                     self = .notFound(message: errorResponse?.error.message ?? "NotFound error")
                 case 405:
-                    self = .notFound(message: errorResponse?.error.message ?? "NotFound error")
+                    self = .invalidHttpMethod(message: errorResponse?.error.message ?? "InvalidHttpMethod error")
                 case 408:
-                    self = .timeout(message: errorResponse?.error.message ?? "Request timeout error: 408", error: responseError, timeoutMillis: 0)
+                    self = .timeout(message: errorResponse?.error.message ?? "RequestTimeout error: 408", error: responseError, timeoutMillis: 0)
                 case 413:
                     self = .payloadTooLarge(message: errorResponse?.error.message ?? "PayloadTooLarge error")
                 case 499:

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -43,9 +43,8 @@ public enum BKTError: Error, Equatable {
         case (.network(let m1, _), .network(let m2, _)),
              (.unknown(let m1, _), .unknown(let m2, _)):
             return m1 == m2
-        case (.unknownServer(let m1, _, let c1), .unknownServer(let m2, _, let c2)):
-            return m1 == m2 && c1 == c2
-        case (.redirectRequest(let m1, let c1), .redirectRequest(let m2, let c2)):
+        case (.unknownServer(let m1, _, let c1), .unknownServer(let m2, _, let c2)),
+             (.redirectRequest(let m1, let c1), .redirectRequest(let m2, let c2)):
             return m1 == m2 && c1 == c2
         default:
             return false

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -651,12 +651,12 @@ class ApiClientTests: XCTestCase {
             timeoutMillis: 100) { (result: Result<(MockResponse, URLResponse), Error>) in
             switch result {
             case .success((let response, _)):
-                XCTAssertEqual(response, mockResponse)
+                XCTFail("should not success")
             case .failure(let error):
                 guard
                     let error = error as? ResponseError,
                     case .unacceptableCode(let code, _) = error, code == 302 else {
-                    XCTFail()
+                    XCTFail("code should be 302")
                     return
                 }
             }

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -597,6 +597,7 @@ class ApiClientTests: XCTestCase {
         wait(for: [expectation], timeout: 1)
     }
     
+    // https://github.com/bucketeer-io/ios-client-sdk/issues/65
     func testSendSuccessButGotRedirectResponse() throws {
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 2

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -596,6 +596,73 @@ class ApiClientTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1)
     }
+    
+    func testSendSuccessButGotRedirectResponse() throws {
+        let expectation = XCTestExpectation()
+        expectation.expectedFulfillmentCount = 2
+
+        let mockRequestBody = MockRequestBody()
+        let mockResponse = MockResponse()
+        let data = try JSONEncoder().encode(mockResponse)
+
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = "path"
+        let apiKey = "x:api-key"
+
+        let session = MockSession(
+            configuration: .default,
+            requestHandler: { request in
+                XCTAssertEqual(request.httpMethod, "POST")
+                XCTAssertEqual(request.url?.host, apiEndpointURL.host)
+                XCTAssertEqual(request.url?.path, "/\(path)")
+                XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], apiKey)
+                XCTAssertEqual(request.timeoutInterval, 0.1)
+                let data = request.httpBody ?? Data()
+                let jsonString = String(data: data, encoding: .utf8) ?? ""
+                let expected = """
+{
+  "value" : "body"
+}
+"""
+                XCTAssertEqual(jsonString, expected)
+                expectation.fulfill()
+            },
+            data: data,
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 302,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: apiKey,
+            featureTag: "tag1",
+            defaultRequestTimeoutMills: 200,
+            session: session,
+            logger: nil
+        )
+        api.send(
+            requestBody: mockRequestBody,
+            path: path,
+            timeoutMillis: 100) { (result: Result<(MockResponse, URLResponse), Error>) in
+            switch result {
+            case .success((let response, _)):
+                XCTAssertEqual(response, mockResponse)
+            case .failure(let error):
+                guard
+                    let error = error as? ResponseError,
+                    case .unacceptableCode(let code, _) = error, code == 302 else {
+                    XCTFail()
+                    return
+                }
+            }
+            expectation.fulfill()
+        }
+        wait(for: [expectation], timeout: 1)
+    }
 
     func testTaskFailureWithoutError() throws {
         let expectation = XCTestExpectation()

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -596,7 +596,7 @@ class ApiClientTests: XCTestCase {
         }
         wait(for: [expectation], timeout: 1)
     }
-    
+
     // https://github.com/bucketeer-io/ios-client-sdk/issues/65
     func testSendSuccessButGotRedirectResponse() throws {
         let expectation = XCTestExpectation()

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -168,6 +168,10 @@ class BKTErrorTests: XCTestCase {
             )
         )
         assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 413, response: nil)),
+            .payloadTooLarge(message: "PayloadTooLarge error")
+        )
+        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 499, response: nil)),
             .clientClosed(message: "Client Closed Request error")
         )

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -196,6 +196,9 @@ class BKTErrorTests: XCTestCase {
             case .timeout:
                 metricsEventData = .timeoutError(.init(apiId: apiId, labels: ["key":"value", "timeout": "4.5"]))
                 metricsEventType = .timeoutError
+            case .invalidHttpMethod:
+                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+                metricsEventType = .networkError
             case .payloadTooLarge:
                 metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .networkError

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -196,6 +196,12 @@ class BKTErrorTests: XCTestCase {
             case .timeout:
                 metricsEventData = .timeoutError(.init(apiId: apiId, labels: ["key":"value", "timeout": "4.5"]))
                 metricsEventType = .timeoutError
+            case .payloadTooLarge:
+                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+                metricsEventType = .networkError
+            case .redirectRequest:
+                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
+                metricsEventType = .networkError
             case .network:
                 metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .networkError

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -350,6 +350,7 @@ extension BKTError: CaseIterable {
         .network(message: "network", error: TestError.network),
         .illegalArgument(message: "illegalArgument"),
         .illegalState(message: "illegalState"),
+        .invalidHttpMethod(message: "invalidHttpMethod"),
         .unknownServer(message: "unknownServer", error: TestError.unknownServer, statusCode: 450),
         .unknown(message: "unknown", error: TestError.unknown)
     ]

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -196,15 +196,12 @@ class BKTErrorTests: XCTestCase {
             case .timeout:
                 metricsEventData = .timeoutError(.init(apiId: apiId, labels: ["key":"value", "timeout": "4.5"]))
                 metricsEventType = .timeoutError
-            case .invalidHttpMethod:
-                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
-                metricsEventType = .networkError
             case .payloadTooLarge:
-                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
-                metricsEventType = .networkError
+                metricsEventData = .payloadTooLarge(.init(apiId: apiId, labels: labels))
+                metricsEventType = .payloadTooLarge
             case .redirectRequest:
-                metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
-                metricsEventType = .networkError
+                metricsEventData = .redirectRequest(.init(apiId: apiId, labels: ["key":"value", "response_code": "302"]))
+                metricsEventType = .redirectRequest
             case .network:
                 metricsEventData = .networkError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .networkError
@@ -229,7 +226,7 @@ class BKTErrorTests: XCTestCase {
             case .apiServer:
                 metricsEventData = .internalServerError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .internalServerError
-            case .illegalArgument, .illegalState:
+            case .illegalArgument, .illegalState, .invalidHttpMethod:
                 metricsEventData = .internalSdkError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .internalError
             case .unknown:
@@ -271,10 +268,12 @@ extension BKTError: CaseIterable {
     }
 
     public static var allCases: [BKTError] = [
+        .redirectRequest(message: "redirectRequest", statusCode: 302),
         .badRequest(message: "badRequest"),
         .unauthorized(message: "unauthorized"),
         .forbidden(message: "forbidden"),
         .notFound(message: "notFound"),
+        .payloadTooLarge(message: "payloadTooLarge"),
         .clientClosed(message: "clientClosed"),
         .unavailable(message: "unavailable"),
         .apiServer(message: "apiServer"),

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -242,7 +242,7 @@ class BKTErrorTests: XCTestCase {
                         labels: [
                             "key": "value",
                             "error_message": "unknownServer",
-                            "response_status_code": "450"
+                            "response_code": "450"
                         ]
                     )
                 )

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Bucketeer
 
+// swiftlint:disable type_body_length
 class BKTErrorTests: XCTestCase {
     enum SomeError: Error {
         case a
@@ -41,6 +42,18 @@ class BKTErrorTests: XCTestCase {
             .unknown(message: "1", error: SomeError.a),
             .unknown(message: "1", error: SomeError.a)
         )
+        assertEqual(
+            .invalidHttpMethod(message: "1"),
+            .invalidHttpMethod(message: "1")
+        )
+        assertEqual(
+            .payloadTooLarge(message: "1"),
+            .payloadTooLarge(message: "1")
+        )
+        assertEqual(
+            .redirectRequest(message: "1", statusCode: 302),
+            .redirectRequest(message: "1", statusCode: 302)
+        )
 
         // equal with diffrent error
         assertEqual(
@@ -73,6 +86,10 @@ class BKTErrorTests: XCTestCase {
             .timeout(message: "2", error: SomeError.a, timeoutMillis: 1000)
         )
         assertNotEqual(
+            .timeout(message: "1", error: SomeError.a, timeoutMillis: 1000),
+            .timeout(message: "1", error: SomeError.a, timeoutMillis: 2000)
+        )
+        assertNotEqual(
             .network(message: "1", error: SomeError.a),
             .network(message: "2", error: SomeError.a)
         )
@@ -83,8 +100,28 @@ class BKTErrorTests: XCTestCase {
             .unknownServer(message: "2", error: SomeError.a, statusCode: 499)
         )
         assertNotEqual(
+            .unknownServer(message: "1", error: SomeError.a, statusCode: 499),
+            .unknownServer(message: "1", error: SomeError.a, statusCode: 490)
+        )
+        assertNotEqual(
             .unknown(message: "1", error: SomeError.a),
             .unknown(message: "2", error: SomeError.a)
+        )
+        assertNotEqual(
+            .invalidHttpMethod(message: "1"),
+            .invalidHttpMethod(message: "2")
+        )
+        assertNotEqual(
+            .payloadTooLarge(message: "1"),
+            .payloadTooLarge(message: "2")
+        )
+        assertNotEqual(
+            .redirectRequest(message: "1", statusCode: 302),
+            .redirectRequest(message: "2", statusCode: 302)
+        )
+        assertNotEqual(
+            .redirectRequest(message: "1", statusCode: 307),
+            .redirectRequest(message: "1", statusCode: 302)
         )
     }
 
@@ -94,6 +131,14 @@ class BKTErrorTests: XCTestCase {
     }
 
     func testInitWithResponseError() {
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 300, response: nil)),
+            .redirectRequest(message: "RedirectRequest error", statusCode: 300)
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 302, response: nil)),
+            .redirectRequest(message: "RedirectRequest error", statusCode: 302)
+        )
         assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 400, response: nil)),
             .badRequest(message: "BadRequest error")
@@ -111,6 +156,18 @@ class BKTErrorTests: XCTestCase {
             .notFound(message: "NotFound error")
         )
         assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 405, response: nil)),
+            .invalidHttpMethod(message: "InvalidHttpMethod error")
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 408, response: nil)),
+            .timeout(
+                message: "RequestTimeout error: 408",
+                error: ResponseError.unacceptableCode(code: 408, response: nil),
+                timeoutMillis: 0
+            )
+        )
+        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 499, response: nil)),
             .clientClosed(message: "Client Closed Request error")
         )
@@ -119,7 +176,15 @@ class BKTErrorTests: XCTestCase {
             .apiServer(message: "InternalServer error")
         )
         assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 502, response: nil)),
+            .unavailable(message: "Unavailable error")
+        )
+        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 503, response: nil)),
+            .unavailable(message: "Unavailable error")
+        )
+        assertEqual(
+            .init(error: ResponseError.unacceptableCode(code: 504, response: nil)),
             .unavailable(message: "Unavailable error")
         )
         let errorResponse = ErrorResponse(error: .init(code: 450, message: "some error"))
@@ -285,3 +350,4 @@ extension BKTError: CaseIterable {
         .unknown(message: "unknown", error: TestError.unknown)
     ]
 }
+// swiftlint:enable type_body_length


### PR DESCRIPTION
Part of https://github.com/bucketeer-io/bucketeer/issues/799
Related to #65 

# TODO
- [x] Track the 3xx status code as "RedirectRequestException". 
  - [x] add `response_code` via labels
- [x] Track the 413 status code as "PayloadTooLargeException"
- [x] Track 408 status code, and we should handle it as a timeout error.
- [x] Make iOS error handling consistent with Android SDK. Android handles more errors code than iOS SDK. That is  ( 405, 502, 504)
- [x] Implement adding more information via labels for Unknown errors, so we don't spend too much time debugging.
  - [x]  Add `error_message` and `response_code` to the ErrorMetricsEvent labels 

# Tests
- [x] Track the 3xx status code as "RedirectRequestException"
  - [x] add `response_code` via labels
- [x] Track the 413 status code as "PayloadTooLargeException"
- [x] 408 errors, and we should handle it as a timeout error.
- [x] Make iOS error handling consistent with Android SDK.
- [x] Implement adding more information via labels for Unknown errors, so we don't spend too much time debugging.
  - [x]  Add `error_message` and `response_code` to the ErrorMetricsEvent labels 
 
