### PR TITLE
chore: unify public method completion to call on the main thread

### DIFF
--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -101,7 +101,7 @@ extension BKTClient {
                 BKTClient.default = client
             } catch let error {
                 config.logger?.error(error)
-                initializeCompletion(error as? BKTError ?? BKTError.unknown(message: "unknown", error: error))
+                initializeCompletion(error as? BKTError ?? BKTError.unknown(message: "unknown error while returning the initialize completion", error: error))
             }
         }
     }

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -17,6 +17,8 @@ final class BKTClientTests: XCTestCase {
                 try BKTClient.initialize(
                     config: config,
                     user: user, completion: { _ in
+                        // should call back in a main thread
+                        XCTAssertTrue(Thread.isMainThread)
                     }
                 )
                 expectation.fulfill()
@@ -232,6 +234,9 @@ final class BKTClientTests: XCTestCase {
         )
         let client = BKTClient(dataModule: dataModule, dispatchQueue: .global())
         client.fetchEvaluations(timeoutMillis: nil) { error in
+            // should call back in a main thread
+            XCTAssertTrue(Thread.isMainThread)
+
             XCTAssertEqual(error, nil)
             expectation.fulfill()
         }
@@ -319,6 +324,9 @@ final class BKTClientTests: XCTestCase {
         )
         let client = BKTClient(dataModule: dataModule, dispatchQueue: .global())
         client.flush { error in
+            // should call back in a main thread
+            XCTAssertTrue(Thread.isMainThread)
+
             XCTAssertEqual(error, nil)
             expectation.fulfill()
         }


### PR DESCRIPTION
To keep iOS SDK consistent with Android SDK
https://github.com/bucketeer-io/android-client-sdk/pull/129
https://github.com/bucketeer-io/android-client-sdk/pull/133

### Changes
- All callback on the the BKTClient's public method will run on the main thread.
- Updated tests