### PR TITLE
ci: change to use macos-13 instead of macos-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   install-mint:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -41,7 +41,7 @@ jobs:
 
   generate-xcodeProject:
     needs: install-mint
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -72,7 +72,7 @@ jobs:
 
   build:
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -89,7 +89,7 @@ jobs:
 
   build-example:
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -113,7 +113,7 @@ jobs:
   test:
     name: Unit tests
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   e2e:
     name: E2E tests
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -2,11 +2,13 @@ name: Pull Request
 
 on:
   pull_request:
-    paths-ignore:
-      - '*.md'
-      - '.github/**'
-      - Bucketeer/Sources/Internal/Utils/Version.swift
-      - Bucketeer.podspec
+    paths:
+      - "*"
+      - "!*.md"
+      - "!.github/**"
+      - ".github/workflows/pull-request.yml"
+      - "!Bucketeer/Sources/Internal/Utils/Version.swift"
+      - "!Bucketeer.podspec"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -14,7 +16,7 @@ concurrency:
 
 jobs:
   install-mint:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -44,7 +46,7 @@ jobs:
 
   lint_swift:
     needs: install-mint
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -62,7 +64,7 @@ jobs:
         run: make run-lint
 
   lint_pod:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
       - name: Lint Pods
@@ -70,7 +72,7 @@ jobs:
 
   generate-xcodeProject:
     needs: install-mint
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -101,7 +103,7 @@ jobs:
 
   build:
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -118,7 +120,7 @@ jobs:
 
   build-example:
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 
@@ -141,7 +143,7 @@ jobs:
 
   test:
     needs: generate-xcodeProject
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - uses: actions/checkout@v3
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,8 @@ XCODEBUILD=xcodebuild
 
 OPTIONS=\
 	-project $(APP_NAME).xcodeproj \
-	-scheme $(SCHEME)
+	-scheme $(SCHEME) \
+	-CODE_SIGNING_ALLOWED=NO
 
 EXAMPLE_OPTIONS=\
 	-project $(APP_NAME).xcodeproj \


### PR DESCRIPTION
Because `macos-13` uses 4 CPU cores instead of 3 compared to `macos-latest`, I'm changing it to improve performance.

Reference:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories