### PR TITLE
test: fix e2e flaky test

### DIFF
--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -61,7 +61,7 @@ final class E2EEventTests: XCTestCase {
             try await Task.sleep(nanoseconds: 10_000_000)
             let events = try component.dataModule.eventSQLDao.getEvents()
             // It includes the Latency and ResponseSize metrics
-            XCTAssertEqual(events.count, 7)
+            XCTAssertTrue(events.count >= 5)
             XCTAssertTrue(events.contains { event in
                 if case .evaluation = event.type,
                    case .evaluation(let data) = event.event,
@@ -111,7 +111,7 @@ final class E2EEventTests: XCTestCase {
             try await Task.sleep(nanoseconds: 10_000_000)
             let events = try component.dataModule.eventSQLDao.getEvents()
             // It includes the Latency and ResponseSize metrics
-            XCTAssertEqual(events.count, 7)
+            XCTAssertTrue(events.count >= 5)
             XCTAssertTrue(events.contains { event in
                 if case .evaluation = event.type,
                    case .evaluation(let data) = event.event,


### PR DESCRIPTION
Fixes test: https://github.com/bucketeer-io/ios-client-sdk/issues/74

Because the CI can be really slow when the test setup process finishes, the test might not run right after the initializing.
So, when the test runs, the first 2 events are already sent in the background, making the test fail randomly.

Since the test created 5 events, I changed the condition from `==` to `>=`.

Test result.
https://github.com/bucketeer-io/ios-client-sdk/actions/runs/8202850924/job/22434504119