### PR TITLE
fix: .unknow error when handle invalid JSON responses

### DIFF
--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -145,33 +145,34 @@ final class ApiClientImpl: ApiClient {
             var result : Result<(Response, URLResponse), Error>?
             let responseParser : (Data?, URLResponse?, Error?) -> Result<(Response, URLResponse), Error> = { data, urlResponse, error in
                 guard let urlResponse = urlResponse as? HTTPURLResponse else {
-                    // error is not related to network domain
+                    // error is not from server
                     guard let error = error else {
                         return .failure(ResponseError.unknown(urlResponse))
                     }
                     return .failure(error)
                 }
 
+                let statusCode = urlResponse.statusCode
+                guard 200..<300 ~= statusCode else {
+                    // UnacceptableCode
+                    let response: ErrorResponse?
+                    if let data = data {
+                        response = try? JSONDecoder().decode(ErrorResponse.self, from: data)
+                    } else {
+                        response = nil
+                    }
+                    let error = ResponseError.unacceptableCode(code: statusCode, response: response)
+                    return .failure(error)
+                }
+                // Success code
+                guard let data = data else {
+                    return .failure(ResponseError.invalidJSONResponse(code: statusCode, error: nil))
+                }
                 do {
-                    guard 200..<300 ~= urlResponse.statusCode else {
-                        // UnacceptableCode
-                        let response: ErrorResponse?
-                        if let data = data {
-                            response = try? JSONDecoder().decode(ErrorResponse.self, from: data)
-                        } else {
-                            response = nil
-                        }
-                        let error = ResponseError.unacceptableCode(code: urlResponse.statusCode, response: response)
-                        return .failure(error)
-                    }
-                    // Success code
-                    guard let data = data else {
-                        return .failure(ResponseError.unknown(urlResponse))
-                    }
                     let response = try JSONDecoder().decode(Response.self, from: data)
                     return .success((response, urlResponse))
                 } catch let error {
-                    return .failure(error)
+                    return .failure(ResponseError.invalidJSONResponse(code: statusCode, error: error))
                 }
             }
 
@@ -212,6 +213,7 @@ final class ApiClientImpl: ApiClient {
 }
 
 enum ResponseError: Error {
+    case invalidJSONResponse(code: Int, error: Error?)
     case unknown(URLResponse?)
     case unacceptableCode(code: Int, response: ErrorResponse?)
 }

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -101,8 +101,8 @@ extension BKTError : LocalizedError {
                     message = "[\(urlResponse.statusCode)] \(urlResponse)"
                 }
                 self = .network(message: "Network connection error: \(message)", error: error)
-            case .invalidJSONResponse(let code, let sourceError):
-                let message: String = "invaild JSON response for status \(code) \(String(describing: sourceError?.localizedDescription))"
+            case .invalidJSONResponse(let code, _):
+                let message: String = "invaild JSON response for status \(code)"
                 self = .unknownServer(message: "Unknown server error: \(message)", error: error, statusCode: code)
             }
             return

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -101,6 +101,9 @@ extension BKTError : LocalizedError {
                     message = "[\(urlResponse.statusCode)] \(urlResponse)"
                 }
                 self = .network(message: "Network connection error: \(message)", error: error)
+            case .invalidJSONResponse(let code, let sourceError):
+                let message: String = "invaild JSON response for status \(code) \(String(describing: sourceError?.localizedDescription))"
+                self = .unknownServer(message: "Unknown server error: \(message)", error: error, statusCode: code)
             }
             return
         }

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1152,25 +1152,25 @@ class ApiClientTests: XCTestCase {
     func testTaskFailWithUnacceptableCode() throws {
         let mockDataReponse = try JSONEncoder().encode(MockResponse())
         let cases = [
-            ResponseCase(statusCode:300, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:300, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:300, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:300, data: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:300, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:300, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:300, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:300, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
 
-            ResponseCase(statusCode:400, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:400, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:400, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:400, data: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:400, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:400, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:400, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:400, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
 
-            ResponseCase(statusCode:500, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:500, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:500, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:500, data: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:500, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:500, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:500, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:500, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
 
-            ResponseCase(statusCode:499, data: Data("".utf8), name: "Case: empty string for the unknown server error"),
-            ResponseCase(statusCode:499, data: Data("okay".utf8), name: "Case: random string for the unknown server error"),
-            ResponseCase(statusCode:499, data: nil, name: "Case: nil for the unknown server error"),
-            ResponseCase(statusCode:499, data: mockDataReponse, name: "Case: vaild JSON for the unknown server error")
+            ResponseCase(statusCode:499, bodyResponse: Data("".utf8), name: "Case: empty string for the unknown server error"),
+            ResponseCase(statusCode:499, bodyResponse: Data("okay".utf8), name: "Case: random string for the unknown server error"),
+            ResponseCase(statusCode:499, bodyResponse: nil, name: "Case: nil for the unknown server error"),
+            ResponseCase(statusCode:499, bodyResponse: mockDataReponse, name: "Case: vaild JSON for the unknown server error")
         ]
 
         var expectations = [XCTestExpectation]()
@@ -1179,7 +1179,7 @@ class ApiClientTests: XCTestCase {
             expectation.expectedFulfillmentCount = 2
 
             let mockRequestBody = MockRequestBody()
-            let data = testCase.data
+            let data = testCase.bodyResponse
 
             let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
             let path = "path"
@@ -1245,20 +1245,20 @@ class ApiClientTests: XCTestCase {
     func testTaskSuccessWithAcceptableCode() throws {
         let mockDataReponse = try JSONEncoder().encode(MockResponse())
         let cases = [
-            ResponseCase(statusCode:200, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:200, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:200, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:200, data: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:200, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:200, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:200, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:200, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
 
-            ResponseCase(statusCode:201, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:201, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:201, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:201, data: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:201, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:201, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:201, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:201, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
 
-            ResponseCase(statusCode:204, data: Data("".utf8), name: "Case: empty string"),
-            ResponseCase(statusCode:204, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:204, data: nil, name: "Case: nil"),
-            ResponseCase(statusCode:204, data: mockDataReponse, name: "Case: vaild JSON")
+            ResponseCase(statusCode:204, bodyResponse: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:204, bodyResponse: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:204, bodyResponse: nil, name: "Case: nil"),
+            ResponseCase(statusCode:204, bodyResponse: mockDataReponse, name: "Case: vaild JSON")
         ]
 
         var expectations = [XCTestExpectation]()
@@ -1267,7 +1267,7 @@ class ApiClientTests: XCTestCase {
             expectation.expectedFulfillmentCount = 2
 
             let mockRequestBody = MockRequestBody()
-            let data = testCase.data
+            let data = testCase.bodyResponse
 
             let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
             let path = "path"
@@ -1328,7 +1328,7 @@ class ApiClientTests: XCTestCase {
 
 struct ResponseCase {
     let statusCode: Int
-    let data: Data?
+    let bodyResponse: Data?
     let name: String
 }
 // swiftlint:enable type_body_length file_length

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1149,17 +1149,28 @@ class ApiClientTests: XCTestCase {
         wait(for: [expectation], timeout: 0.1)
     }
 
-    func testTaskFailWithUnacceptableCodeAndEmptyResponse() throws {
+    func testTaskFailWithUnacceptableCode() throws {
+        let mockDataReponse = try JSONEncoder().encode(MockResponse())
         let cases = [
+            ResponseCase(statusCode:300, data: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:300, data: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:300, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:300, data: mockDataReponse, name: "Case: vaild JSON"),
+
             ResponseCase(statusCode:400, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:400, data: Data("okay".utf8), name: "Case: random string"),
             ResponseCase(statusCode:400, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:400, data: mockDataReponse, name: "Case: vaild JSON"),
+
             ResponseCase(statusCode:500, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:500, data: Data("okay".utf8), name: "Case: random string"),
             ResponseCase(statusCode:500, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:500, data: mockDataReponse, name: "Case: vaild JSON"),
+
             ResponseCase(statusCode:499, data: Data("".utf8), name: "Case: empty string for the unknown server error"),
             ResponseCase(statusCode:499, data: Data("okay".utf8), name: "Case: random string for the unknown server error"),
-            ResponseCase(statusCode:499, data: nil, name: "Case: nil for the unknown server error")
+            ResponseCase(statusCode:499, data: nil, name: "Case: nil for the unknown server error"),
+            ResponseCase(statusCode:499, data: mockDataReponse, name: "Case: vaild JSON for the unknown server error")
         ]
 
         var expectations = [XCTestExpectation]()
@@ -1231,11 +1242,23 @@ class ApiClientTests: XCTestCase {
         wait(for: expectations, timeout: 2)
     }
 
-    func testTaskSuccessWithEmptyResponse() throws {
+    func testTaskSuccessWithAcceptableCode() throws {
+        let mockDataReponse = try JSONEncoder().encode(MockResponse())
         let cases = [
             ResponseCase(statusCode:200, data: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:200, data: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:200, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:200, data: mockDataReponse, name: "Case: vaild JSON"),
+
+            ResponseCase(statusCode:201, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:201, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:200, data: nil, name: "Case: nil")
+            ResponseCase(statusCode:201, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:201, data: mockDataReponse, name: "Case: vaild JSON"),
+
+            ResponseCase(statusCode:204, data: Data("".utf8), name: "Case: empty string"),
+            ResponseCase(statusCode:204, data: Data("okay".utf8), name: "Case: random string"),
+            ResponseCase(statusCode:204, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:204, data: mockDataReponse, name: "Case: vaild JSON")
         ]
 
         var expectations = [XCTestExpectation]()
@@ -1293,7 +1316,7 @@ class ApiClientTests: XCTestCase {
                 case .success((_, _)):
                     expectation.fulfill()
                 case .failure(let error):
-                    XCTFail("should success - case: \(testCase.name)")
+                    XCTFail("should success - case: \(testCase.name) - status code \(testCase.statusCode) - error \(error)")
                 }
                 expectation.fulfill()
             }

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1248,23 +1248,23 @@ class ApiClientTests: XCTestCase {
             ResponseCase(statusCode:200, bodyResponse: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:200, bodyResponse: Data("okay".utf8), name: "Case: random string"),
             ResponseCase(statusCode:200, bodyResponse: nil, name: "Case: nil"),
-            ResponseCase(statusCode:200, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:200, bodyResponse: mockDataReponse, name: "Case: vaild JSON", shouldSuccess: true),
 
             ResponseCase(statusCode:201, bodyResponse: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:201, bodyResponse: Data("okay".utf8), name: "Case: random string"),
             ResponseCase(statusCode:201, bodyResponse: nil, name: "Case: nil"),
-            ResponseCase(statusCode:201, bodyResponse: mockDataReponse, name: "Case: vaild JSON"),
+            ResponseCase(statusCode:201, bodyResponse: mockDataReponse, name: "Case: vaild JSON", shouldSuccess: true),
 
             ResponseCase(statusCode:204, bodyResponse: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:204, bodyResponse: Data("okay".utf8), name: "Case: random string"),
             ResponseCase(statusCode:204, bodyResponse: nil, name: "Case: nil"),
-            ResponseCase(statusCode:204, bodyResponse: mockDataReponse, name: "Case: vaild JSON")
+            ResponseCase(statusCode:204, bodyResponse: mockDataReponse, name: "Case: vaild JSON", shouldSuccess: true)
         ]
 
         var expectations = [XCTestExpectation]()
         cases.forEach { testCase in
             let expectation = XCTestExpectation(description: testCase.name)
-            expectation.expectedFulfillmentCount = 2
+            expectation.expectedFulfillmentCount = 1
 
             let mockRequestBody = MockRequestBody()
             let data = testCase.bodyResponse
@@ -1275,22 +1275,7 @@ class ApiClientTests: XCTestCase {
 
             let session = MockSession(
                 configuration: .default,
-                requestHandler: { request in
-                    XCTAssertEqual(request.httpMethod, "POST")
-                    XCTAssertEqual(request.url?.host, apiEndpointURL.host)
-                    XCTAssertEqual(request.url?.path, "/\(path)")
-                    XCTAssertEqual(request.allHTTPHeaderFields?["Authorization"], apiKey)
-                    XCTAssertEqual(request.timeoutInterval, 0.1)
-                    let data = request.httpBody ?? Data()
-                    let jsonString = String(data: data, encoding: .utf8) ?? ""
-                    let expected = """
-    {
-      "value" : "body"
-    }
-    """
-                    XCTAssertEqual(jsonString, expected)
-                    expectation.fulfill()
-                },
+                requestHandler: nil,
                 data: data,
                 response: HTTPURLResponse(
                     url: apiEndpointURL.appendingPathComponent(path),
@@ -1314,9 +1299,19 @@ class ApiClientTests: XCTestCase {
                 timeoutMillis: 100) { (result: Result<(MockResponse, URLResponse), Error>) in
                 switch result {
                 case .success((_, _)):
-                    expectation.fulfill()
+                    if (!testCase.shouldSuccess) {
+                        XCTFail("should not success - case: \(testCase.name) - status code \(testCase.statusCode)")
+                    }
                 case .failure(let error):
-                    XCTFail("should success - case: \(testCase.name) - status code \(testCase.statusCode) - error \(error)")
+                    guard
+                        let error = error as? ResponseError,
+                        case .invalidJSONResponse(let code, _) = error, code == testCase.statusCode else {
+                        XCTFail("error should be .invalidJSONResponse, code should be \(testCase.statusCode) for case: \(testCase.name)")
+                        return
+                    }
+                    if (testCase.shouldSuccess) {
+                        XCTFail("should success - case: \(testCase.name) - status code \(testCase.statusCode) - error \(error)")
+                    }
                 }
                 expectation.fulfill()
             }
@@ -1326,9 +1321,17 @@ class ApiClientTests: XCTestCase {
     }
 }
 
-struct ResponseCase {
+class ResponseCase {
+    internal init(statusCode: Int, bodyResponse: Data? = nil, name: String, shouldSuccess: Bool = false) {
+        self.statusCode = statusCode
+        self.bodyResponse = bodyResponse
+        self.name = name
+        self.shouldSuccess = shouldSuccess
+    }
+
     let statusCode: Int
     let bodyResponse: Data?
     let name: String
+    let shouldSuccess: Bool
 }
 // swiftlint:enable type_body_length file_length

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1153,10 +1153,13 @@ class ApiClientTests: XCTestCase {
         let cases = [
             ResponseCase(statusCode:400, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:400, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:400, data: nil, name: "Case: Nil"),
+            ResponseCase(statusCode:400, data: nil, name: "Case: nil"),
             ResponseCase(statusCode:500, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:500, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:500, data: nil, name: "Case: Nil")
+            ResponseCase(statusCode:500, data: nil, name: "Case: nil"),
+            ResponseCase(statusCode:499, data: Data("".utf8), name: "Case: empty string for the unknown server error"),
+            ResponseCase(statusCode:499, data: Data("okay".utf8), name: "Case: random string for the unknown server error"),
+            ResponseCase(statusCode:499, data: nil, name: "Case: nil for the unknown server error")
         ]
 
         var expectations = [XCTestExpectation]()
@@ -1232,7 +1235,7 @@ class ApiClientTests: XCTestCase {
         let cases = [
             ResponseCase(statusCode:200, data: Data("".utf8), name: "Case: empty string"),
             ResponseCase(statusCode:201, data: Data("okay".utf8), name: "Case: random string"),
-            ResponseCase(statusCode:200, data: nil, name: "Case: Nil")
+            ResponseCase(statusCode:200, data: nil, name: "Case: nil")
         ]
 
         var expectations = [XCTestExpectation]()

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -1239,7 +1239,7 @@ class ApiClientTests: XCTestCase {
             }
             expectations.append(expectation)
         }
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 10)
     }
 
     func testTaskSuccessWithAcceptableCode() throws {
@@ -1322,7 +1322,7 @@ class ApiClientTests: XCTestCase {
             }
             expectations.append(expectation)
         }
-        wait(for: expectations, timeout: 2)
+        wait(for: expectations, timeout: 10)
     }
 }
 

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -132,6 +132,14 @@ class BKTErrorTests: XCTestCase {
 
     func testInitWithResponseError() {
         assertEqual(
+            .init(error: ResponseError.invalidJSONResponse(code: 200, error: SomeError.a)),
+            .unknownServer(
+                message: "Unknown server error: invaild JSON response for status 200",
+                error: ResponseError.invalidJSONResponse(code: 200, error: SomeError.a),
+                statusCode: 200
+            )
+        )
+        assertEqual(
             .init(error: ResponseError.unacceptableCode(code: 300, response: nil)),
             .redirectRequest(message: "RedirectRequest error", statusCode: 300)
         )


### PR DESCRIPTION
Related to https://github.com/bucketeer-io/ios-client-sdk/issues/64
We added some tests to see how the current code handles invalid JSON responses

### Changes
Fixed the issue where the status code couldn't be captured when 
- [x] The server responded with an unacceptable code and a nil response body.
- [x] The server responded with a 2xx status code and an invalid JSON response body.

---

This pull request introduces several changes to the `Bucketeer` Swift package, primarily focusing on improving error handling for API responses. The key changes include updates to the `ApiClientImpl` class to better handle HTTP responses, the addition of a new error type in the `ResponseError` enum, and corresponding updates to error handling in the `BKTError` class. Additionally, there are new test cases in `ApiClientTests` and `BKTErrorTests` to validate these changes.

Here are the most important changes:

Improvements to HTTP response handling:

* [`Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift`](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eL147-R175): Updated the `responseParser` closure to handle different scenarios of HTTP responses more accurately. This includes handling cases where the HTTP response is not available, the status code is not within the acceptable range, or the response data is not available or cannot be decoded into the expected `Response` type.

Error handling enhancements:

* [`Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift`](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eR216): Added a new error case `invalidJSONResponse` in the `ResponseError` enum to represent scenarios where the response data cannot be decoded into the expected `Response` type.
* [`Bucketeer/Sources/Public/BKTError.swift`](diffhunk://#diff-cbe40a73c2775ae6d2ec397ae2386f798bfb68541dbc5ef1b6595d87b1fd8ca7R104-R106): Updated the `BKTError` class to handle the new `invalidJSONResponse` error case from the `ResponseError` enum.

Test case additions:

* [`BucketeerTests/ApiClientTests.swift`](diffhunk://#diff-b8becb5ad1412af7c03a24156dc3f8fa88fd400c78fbeb018cf35e82a8c0501dR1151-R1335): Added new test cases in `ApiClientTests` to validate the handling of different HTTP response scenarios in `ApiClientImpl`.
* [`BucketeerTests/BKTErrorTests.swift`](diffhunk://#diff-d7f8fcba85de6dc1d08876a88e476be4098b10aa548f4769c8b6a65f3f663cadR134-R141): Added a new test case in `BKTErrorTests` to validate the handling of the new `invalidJSONResponse` error case in `BKTError`.