### PR TITLE
ci: fix upload xcframework file

### DIFF
--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -30,7 +30,7 @@ jobs:
 
   upload-xcframework:
     needs: create-xcframework
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: output-xcframework-file
-          path: ./FrameworkBuild/Bucketeer.xcframework.zip
+          path: ./FrameworkBuild
 
       - name: Upload Release Framework
         env:


### PR DESCRIPTION
This pull request includes a change to the `.github/workflows/upload-framework.yml` file. The change modifies the `runs-on` property under `upload-xcframework` from `ubuntu-latest` to `macos-latest`. This change indicates that the `upload-xcframework` job will now run on a macOS environment instead of an Ubuntu environment in GitHub Actions.