### PR TITLE
feat: comply with new iOS third-party SDK requirements

### DIFF
--- a/Bucketeer.podspec
+++ b/Bucketeer.podspec
@@ -17,6 +17,9 @@ Pod::Spec.new do |s|
     :git => 'https://github.com/bucketeer-io/ios-client-sdk.git',
     :tag => "v#{s.version}",
   }
+  s.resource_bundles = {
+    'BucketeerPrivacyInfo' => ['Bucketeer/PrivacyInfo.xcprivacy'],
+  }
 
   s.license = {
     :type => 'Apache License, Version 2.0',

--- a/Bucketeer/PrivacyInfo.xcprivacy
+++ b/Bucketeer/PrivacyInfo.xcprivacy
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeUserID</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeProductPersonalization</string>
+				<string>NSPrivacyCollectedDataTypePurposeAppFunctionality</string>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherDiagnosticData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<false/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string>NSPrivacyCollectedDataTypePurposeAnalytics</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
         .target(
             name: "Bucketeer",
             path: "./Bucketeer",
-            resources: [.copy("PrivacyInfo.xcprivacy")]),
+            resources: [.process("PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "BucketeerTests",
             dependencies: ["Bucketeer"],

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
     targets: [
         .target(
             name: "Bucketeer",
-            path: "./Bucketeer"
-        ),
+            path: "./Bucketeer",
+            resources: [.copy("PrivacyInfo.xcprivacy")]),
         .testTarget(
             name: "BucketeerTests",
             dependencies: ["Bucketeer"],


### PR DESCRIPTION
Will close #79 

This PR adds a new manifest file required to any iOS 3rd SDK from this year. It also included the privacy file to the Swift package and the cocoapods podspec.

The privacy manifest file will be added to the XCode project as a resource file when we generate the XCode project using the XCodeGen.