### PR TITLE
test: fix EventForegroundTask.testStartWithUpdateEvents failing randomly

### DIFF
--- a/BucketeerTests/EventForegroundTaskTests.swift
+++ b/BucketeerTests/EventForegroundTaskTests.swift
@@ -45,10 +45,10 @@ class EventForegroundTaskTests: XCTestCase {
             expectation.fulfill()
         }
         let config = BKTConfig.mock(
-            eventsFlushInterval: 10,
+            eventsFlushInterval: 5000,
             eventsMaxQueueSize: 3,
-            pollingInterval: 2000,
-            backgroundPollingInterval: 1000
+            pollingInterval: 10000,
+            backgroundPollingInterval: 20000
         )
         let component = MockComponent(
             config: config,


### PR DESCRIPTION
Close #80 

This pull request (PR) updates the flush interval for the test case `EventForegroundTaskTests.testStartWithUpdateEvents`. This change ensures that additional update events won't be triggered by the schedule timer when the CI process runs slowly. That will cause the test fail.
