### PR TITLE
fix: missing error_message when reporting client's unknown error

### DIFF
--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -407,8 +407,18 @@ extension BKTError {
                 )
             )
             metricsEventType = .unknownError
-        case .unknown:
-            metricsEventData = .unknownError(.init(apiId: apiId, labels: labels))
+        case .unknown(let message, _):
+            metricsEventData = .unknownError(
+                .init(
+                    apiId: apiId,
+                    labels: labels.merging(
+                        [
+                            "error_message":message
+                        ]
+                        , uniquingKeysWith: { (first, _) in first }
+                    )
+                )
+            )
             metricsEventType = .unknownError
         }
         return .metrics(.init(

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -307,7 +307,15 @@ class BKTErrorTests: XCTestCase {
                 metricsEventData = .internalSdkError(.init(apiId: apiId, labels: labels))
                 metricsEventType = .internalError
             case .unknown:
-                metricsEventData = .unknownError(.init(apiId: apiId, labels: labels))
+                metricsEventData = .unknownError(
+                    .init(
+                        apiId: apiId,
+                        labels: [
+                            "key": "value",
+                            "error_message": "unknown"
+                        ]
+                    )
+                )
                 metricsEventType = .unknownError
             case .unknownServer:
                 metricsEventData = .unknownError(


### PR DESCRIPTION
This PR will fix the missing `error_message` when reporting an unknown error from SDK code (it is different case with unknown error from the server API)