### PR TITLE
fix: skip generating error events for unauthorized or forbidden errors

### DIFF
--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -168,7 +168,15 @@ final class EventInteractorImpl: EventInteractor {
     }
 
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws {
+        try trackApiFailureMetricsEvent(error: error, featureTag: featureTag, apiId: .getEvaluations)
+    }
 
+    func trackRegisterEventsFailure(error: BKTError) throws {
+        // note: using the same tag in BKConfig.featureTag
+        try trackApiFailureMetricsEvent(error: error, featureTag: featureTag, apiId: .registerEvents)
+    }
+
+    func trackApiFailureMetricsEvent(error: BKTError, featureTag: String, apiId: ApiId) throws {
         if case .forbidden = error {
             logger?.warn(message: "An forbidden error occurred. Please check your API Key.")
             logger?.error(error)
@@ -182,25 +190,7 @@ final class EventInteractorImpl: EventInteractor {
         }
 
         let eventData = error.toMetricsEventData(
-            apiId: .getEvaluations,
-            labels: ["tag": featureTag],
-            currentTimeSeconds: clock.currentTimeSeconds,
-            sdkVersion: sdkVersion,
-            metadata: metadata
-        )
-        try trackMetricsEvent(events: [
-            .init(
-                id: idGenerator.id(),
-                event: eventData,
-                type: .metrics
-            )
-        ])
-    }
-
-    func trackRegisterEventsFailure(error: BKTError) throws {
-        // note: using the same tag in BKConfig.featureTag
-        let eventData = error.toMetricsEventData(
-            apiId: .registerEvents,
+            apiId: apiId,
             labels: ["tag": featureTag],
             currentTimeSeconds: clock.currentTimeSeconds,
             sdkVersion: sdkVersion,

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -168,6 +168,19 @@ final class EventInteractorImpl: EventInteractor {
     }
 
     func trackFetchEvaluationsFailure(featureTag: String, error: BKTError) throws {
+
+        if case .forbidden = error {
+            logger?.warn(message: "An forbidden error occurred. Please check your API Key.")
+            logger?.error(error)
+            return
+        }
+
+        if case .unauthorized = error {
+            logger?.warn(message: "An unauthorized error occurred. Please check your API Key.")
+            logger?.error(error)
+            return
+        }
+
         let eventData = error.toMetricsEventData(
             apiId: .getEvaluations,
             labels: ["tag": featureTag],

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -176,7 +176,7 @@ final class EventInteractorImpl: EventInteractor {
         try trackApiFailureMetricsEvent(error: error, featureTag: featureTag, apiId: .registerEvents)
     }
 
-    func trackApiFailureMetricsEvent(error: BKTError, featureTag: String, apiId: ApiId) throws {
+    private func trackApiFailureMetricsEvent(error: BKTError, featureTag: String, apiId: ApiId) throws {
         if case .forbidden = error {
             logger?.warn(message: "An forbidden error occurred. Please check your API Key.")
             logger?.error(error)

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -707,9 +707,17 @@ final class EventInteractorTests: XCTestCase {
             error: .forbidden(message: "forbidden")
         )
 
+        try interactor.trackRegisterEventsFailure(
+            error: .forbidden(message: "forbidden")
+        )
+
         // Simulate unauthorized error - Expectation should also not fulfill
         try interactor.trackFetchEvaluationsFailure(
             featureTag: "featureTag1",
+            error: .unauthorized(message: "unauthorized")
+        )
+
+        try interactor.trackRegisterEventsFailure(
             error: .unauthorized(message: "unauthorized")
         )
 

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -687,5 +687,33 @@ final class EventInteractorTests: XCTestCase {
 
         wait(for: [expectation], timeout: 20)
     }
+
+    func testShouldNotCreateErrorEventForUnauthorizedAndForbiddenExceptions() throws {
+        let expectation = XCTestExpectation(description: "Expectation should not be fulfilled")
+        expectation.isInverted = true // Inverted expectation: Should NOT be fulfilled
+        expectation.assertForOverFulfill = true
+
+        let interactor = self.eventInteractor()
+        let listener = MockEventUpdateListener { _ in
+            // Only fulfill for specific events (if needed, based on other logic)
+            expectation.fulfill()
+        }
+
+        interactor.set(eventUpdateListener: listener)
+
+        // Simulate forbidden error - Expectation should not fulfill for these cases
+        try interactor.trackFetchEvaluationsFailure(
+            featureTag: "featureTag1",
+            error: .forbidden(message: "forbidden")
+        )
+
+        // Simulate unauthorized error - Expectation should also not fulfill
+        try interactor.trackFetchEvaluationsFailure(
+            featureTag: "featureTag1",
+            error: .unauthorized(message: "unauthorized")
+        )
+
+        wait(for: [expectation], timeout: 1)
+    }
 }
 // swiftlint:enable type_body_length file_length

--- a/BucketeerTests/Mock/MockEventSQLDao.swift
+++ b/BucketeerTests/Mock/MockEventSQLDao.swift
@@ -39,7 +39,7 @@ final class MockEventSQLDao: EventSQLDao {
     func delete(ids: [String]) throws {
         lock.lock()
         defer { lock.unlock() }
-        
+
         try deleteEventsHandler?(ids)
         events.removeAll(where: { ids.contains($0.id) })
     }

--- a/BucketeerTests/Mock/MockEventSQLDao.swift
+++ b/BucketeerTests/Mock/MockEventSQLDao.swift
@@ -37,6 +37,9 @@ final class MockEventSQLDao: EventSQLDao {
     }
 
     func delete(ids: [String]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        
         try deleteEventsHandler?(ids)
         events.removeAll(where: { ids.contains($0.id) })
     }

--- a/BucketeerTests/Mock/MockEventSQLDao.swift
+++ b/BucketeerTests/Mock/MockEventSQLDao.swift
@@ -10,6 +10,7 @@ final class MockEventSQLDao: EventSQLDao {
     let getEventsHandler: GetEventsHandler?
     let deleteEventsHandler: DeleteEventsHandler?
     var events: [Event] = []
+    private let lock = NSLock()
 
     init(addEventsHandler: AddEventsHandler? = nil,
          getEventsHandler: GetEventsHandler? = nil,
@@ -24,6 +25,9 @@ final class MockEventSQLDao: EventSQLDao {
     }
 
     func add(events: [Event]) throws {
+        lock.lock()
+        defer { lock.unlock() }
+
         try addEventsHandler?(events)
         self.events.append(contentsOf: events)
     }


### PR DESCRIPTION
part of https://github.com/bucketeer-io/bucketeer/issues/1284

also fix #91 