### PR TITLE
test: skip feature version checking in the e2e tests

### DIFF
--- a/BucketeerTests/E2E/E2EEvaluationTests.swift
+++ b/BucketeerTests/E2E/E2EEvaluationTests.swift
@@ -54,9 +54,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.stringVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: "default"),
-                .init(
+            assertEvaluationDetails(
+                actual: client.stringVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: "default"),
+                expected: .init(
                     featureId: FEATURE_ID_STRING,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -66,9 +66,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: .list([])),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: .list([])),
+                expected: .init(
                     featureId: FEATURE_ID_STRING,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -105,9 +105,9 @@ final class E2EEvaluationTests: XCTestCase {
                 reason: .default
             ))
 
-            XCTAssertEqual(
-                client.intVariationDetails(featureId: FEATURE_ID_INT, defaultValue: 1),
-                .init(
+            assertEvaluationDetails(
+                actual: client.intVariationDetails(featureId: FEATURE_ID_INT, defaultValue: 1),
+                expected: .init(
                     featureId: FEATURE_ID_INT,
                     featureVersion: 4,
                     userId: USER_ID,
@@ -117,9 +117,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_INT, defaultValue: .number(1)),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_INT, defaultValue: .number(1)),
+                expected: .init(
                     featureId: FEATURE_ID_INT,
                     featureVersion: 4,
                     userId: USER_ID,
@@ -157,9 +157,9 @@ final class E2EEvaluationTests: XCTestCase {
                 reason: .default
             ))
 
-            XCTAssertEqual(
-                client.doubleVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: 1.1),
-                .init(
+            assertEvaluationDetails(
+                actual: client.doubleVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: 1.1),
+                expected: .init(
                     featureId: FEATURE_ID_DOUBLE,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -169,9 +169,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.intVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: 1),
-                .init(
+            assertEvaluationDetails(
+                actual: client.intVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: 1),
+                expected: .init(
                     featureId: FEATURE_ID_DOUBLE,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -181,9 +181,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: .number(1.1)),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_DOUBLE, defaultValue: .number(1.1)),
+                expected: .init(
                     featureId: FEATURE_ID_DOUBLE,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -220,9 +220,9 @@ final class E2EEvaluationTests: XCTestCase {
                 reason: .default
             ))
 
-            XCTAssertEqual(
-                client.boolVariationDetails(featureId: FEATURE_ID_BOOLEAN, defaultValue: false),
-                .init(
+            assertEvaluationDetails(
+                actual: client.boolVariationDetails(featureId: FEATURE_ID_BOOLEAN, defaultValue: false),
+                expected: .init(
                     featureId: FEATURE_ID_BOOLEAN,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -232,9 +232,9 @@ final class E2EEvaluationTests: XCTestCase {
                     reason: .default
                 ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_BOOLEAN, defaultValue: .boolean(false)),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_BOOLEAN, defaultValue: .boolean(false)),
+                expected: .init(
                     featureId: FEATURE_ID_BOOLEAN,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -272,9 +272,9 @@ final class E2EEvaluationTests: XCTestCase {
                 reason: .default
             ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_JSON, defaultValue: .dictionary([:])),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_JSON, defaultValue: .dictionary([:])),
+                expected: .init(
                     featureId: FEATURE_ID_JSON,
                     featureVersion: 3,
                     userId: USER_ID,
@@ -309,9 +309,9 @@ final class E2EEvaluationTests: XCTestCase {
                 reason: .rule
             ))
 
-            XCTAssertEqual(
-                client.objectVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: .number(1.0)),
-                .init(
+            assertEvaluationDetails(
+                actual: client.objectVariationDetails(featureId: FEATURE_ID_STRING, defaultValue: .number(1.0)),
+                expected: .init(
                     featureId: FEATURE_ID_STRING,
                     featureVersion: 3,
                     userId: USER_ID,

--- a/BucketeerTests/E2E/E2ETestHelpers.swift
+++ b/BucketeerTests/E2E/E2ETestHelpers.swift
@@ -131,6 +131,20 @@ func assertEvaluation(actual: BKTEvaluation?, expected: BKTEvaluationExpected, f
     }
 }
 
+func assertEvaluationDetails<T>(
+    actual: BKTEvaluationDetails<T>,
+    expected: BKTEvaluationDetails<T>
+) {
+    // Skipped check on the feature version
+    let isEqual = actual.featureId == expected.featureId &&
+        actual.userId == expected.userId &&
+        actual.variationId == expected.variationId &&
+        actual.variationName == expected.variationName &&
+        actual.reason == expected.reason &&
+        actual.variationValue == expected.variationValue
+    XCTAssertTrue(isEqual)
+}
+
 final class E2ELogger: BKTLogger {
     private var prefix: String {
         "Bucketeer E2E "


### PR DESCRIPTION
This pull request addresses an issue with end-to-end test failures and skips check on the`featureVersion`