### PR TITLE
ci: fix e2e tests failing randomly

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,6 +14,8 @@ jobs:
     if: always()
     name: E2E tests
     runs-on: macos-15-xlarge
+    env:
+      XCODE_VERSION: '16.2'
     steps:
       - uses: actions/checkout@v4
 
@@ -22,8 +24,32 @@ jobs:
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
+
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
+
+      # Get macOS version for cache key
+      - name: Get macOS version
+        id: macos-version
+        run: |
+          VERSION=$(sw_vers -productVersion | cut -d. -f1,2)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "Running on macOS $VERSION"
+
+      # Cache Xcode DerivedData and SPM dependencies
+      - name: Cache build artifacts
+        id: cache-build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Developer/Xcode/DerivedData
+            ~/.swiftpm
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Caches/com.apple.dt.Xcode
+          key: ${{ runner.os }}-${{ steps.macos-version.outputs.version }}-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('**/Package.swift', '**/Bucketeer.xcodeproj/project.pbxproj') }}-${{ hashFiles('**/*.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.macos-version.outputs.version }}-xcode-${{ env.XCODE_VERSION }}-${{ hashFiles('**/Package.swift', '**/Bucketeer.xcodeproj/project.pbxproj') }}-
+            ${{ runner.os }}-${{ steps.macos-version.outputs.version }}-xcode-${{ env.XCODE_VERSION }}-
 
       - name: Verify iPhone simulators
         run: |

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Select Xcode version
         run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
 
+      - name: Verify iPhone simulators
+        run: |
+          echo "Available iPhone simulators:"
+          xcrun simctl list devices available | grep "iPhone" || echo "No iPhone simulators found!"
+
       - name: Download environment file
         uses: actions/download-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,9 @@ EXAMPLE_OPTIONS=\
 	-scheme Example
 
 DESTINATION_IPHONE=-destination "name=$(DEVICE)"
-# Destination for iOS Simulator, iphone 16, os 18.2
-DESTINATION=-destination 'id=02D18BF3-B53A-446D-A9C5-D9447E51BA48'
+# Destination for iOS Simulator - using platform and name without specific OS version
+# This will match any available iPhone 16 simulator regardless of OS version
+DESTINATION=-destination 'platform=iOS Simulator,name=iPhone 16'
 
 CLEAN=rm -rf build
 SHOW_BUILD_SETTINGS=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \


### PR DESCRIPTION
Using the ID is problematic because simulator IDs are not stable across different environments. Instead, we should use a more generic destination that will work consistently.