### PR TITLE
build: update the minimum development target vesion to 12.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,10 +22,10 @@ jobs:
         with:
           xcode-version: '16.2'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
@@ -44,16 +44,16 @@ jobs:
         with:
           xcode-version: '16.2'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
 
       - name: Download environment file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
             name: output-environment-file
             path: ./environment.xcconfig
@@ -73,16 +73,16 @@ jobs:
         with:
           xcode-version: '16.2'
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
 
       - name: Download environment file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-environment-file
           path: ./environment.xcconfig

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - main
 
+env:
+  XCODE_VERSION: '16.2'
+
 jobs:
   generate-xcode-project:
     uses: ./.github/workflows/generate-xcode-project.yml
@@ -17,12 +20,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -39,12 +40,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -67,12 +66,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,11 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
       - uses: actions/checkout@v4
 
       - name: Download xcode project file
@@ -34,6 +39,11 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
       - uses: actions/checkout@v4
 
       - name: Download xcode project file
@@ -58,6 +68,11 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
       - uses: actions/checkout@v4
 
       - name: Download xcode project file

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,8 +63,7 @@ jobs:
           CI: true
         run: make build-example
 
-  test:
-    name: Unit tests
+  unit-test:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
@@ -93,7 +92,7 @@ jobs:
       - name: Unit Test
         run: make test-without-building
 
-  e2e:
+  e2e-test:
     name: E2E tests
     needs: generate-xcode-project
     uses: ./.github/workflows/e2e.yml

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
   build:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -32,7 +32,7 @@ jobs:
 
   build-example:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -56,7 +56,7 @@ jobs:
   test:
     name: Unit tests
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -16,7 +16,13 @@ jobs:
     runs-on: macos-14-xlarge
     env:
       XCODE_VERSION: '16.2'
+
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
@@ -24,9 +30,6 @@ jobs:
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
-
-      - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       # Get macOS version for cache key
       - name: Get macOS version

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -3,6 +3,9 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  XCODE_VERSION: '16.2'
+
 jobs:
   generate-xcode-project:
     if: ${{ github.event.workflow  == '.github/workflows/e2e.yml'}}
@@ -14,16 +17,12 @@ jobs:
     if: always()
     name: E2E tests
     runs-on: macos-14-xlarge
-    env:
-      XCODE_VERSION: '16.2'
 
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/generate-xcode-project.yml
+++ b/.github/workflows/generate-xcode-project.yml
@@ -3,16 +3,17 @@ on:
   workflow_dispatch:
   workflow_call:
 
+env:
+  XCODE_VERSION: '16.2'
+
 jobs:
   generate-xcode-project:
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       # Get macOS version for cache key
       - name: Get macOS version

--- a/.github/workflows/generate-xcode-project.yml
+++ b/.github/workflows/generate-xcode-project.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   generate-xcode-project:
-    runs-on: macos-14
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 

--- a/.github/workflows/generate-xcode-project.yml
+++ b/.github/workflows/generate-xcode-project.yml
@@ -7,6 +7,11 @@ jobs:
   generate-xcode-project:
     runs-on: macos-14-xlarge
     steps:
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       # Get macOS version for cache key

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
 
 jobs:
-  validate_pr_title:
+  validate-pr-title:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-cocoapods.yml
+++ b/.github/workflows/publish-cocoapods.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: macos-13
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-cocoapods.yml
+++ b/.github/workflows/publish-cocoapods.yml
@@ -10,7 +10,7 @@ jobs:
   release:
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install Cocoapods
         run: gem install cocoapods

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -19,7 +19,7 @@ jobs:
 
   lint_swift:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
         run: mint run swiftlint --strict
 
   lint_pod:
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
       - name: Lint Pods
@@ -59,7 +59,7 @@ jobs:
 
   build:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -76,7 +76,7 @@ jobs:
 
   build-example:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 
@@ -99,7 +99,7 @@ jobs:
 
   test:
     needs: generate-xcode-project
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+env:
+  XCODE_VERSION: '16.2'
+
 jobs:
 
   generate-xcode-project:
@@ -61,12 +64,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -83,12 +84,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download environment file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
@@ -111,12 +110,10 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - name: Set up Xcode
-        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
-        with:
-          xcode-version: '16.2'
-
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Download xcode project file
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -17,7 +17,7 @@ jobs:
   generate-xcode-project:
     uses: ./.github/workflows/generate-xcode-project.yml
 
-  lint_swift:
+  lint-swift:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
@@ -50,7 +50,7 @@ jobs:
       - name: Lint swift
         run: mint run swiftlint --strict
 
-  lint_pod:
+  lint-pod:
     runs-on: macos-14-xlarge
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
@@ -107,7 +107,7 @@ jobs:
           CI: true
         run: make build-example
 
-  test:
+  unit-test:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -21,7 +21,7 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       # Pre-cache mint packages directory
       - name: Cache Mint packages
@@ -53,7 +53,7 @@ jobs:
   lint_pod:
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Lint Pods
         run: pod lib lint --allow-warnings
 
@@ -61,10 +61,15 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
@@ -78,16 +83,21 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download environment file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-environment-file
           path: ./environment.xcconfig
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj
@@ -101,10 +111,15 @@ jobs:
     needs: generate-xcode-project
     runs-on: macos-14-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - name: Set up Xcode
+        uses: maxim-lobanov/setup-xcode@60606e260d2fc5762a71e64e74b2174e8ea3c8bd # v1.6.0
+        with:
+          xcode-version: '16.2'
+
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Download xcode project file
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: output-xcodeproj-file
           path: ./Bucketeer.xcodeproj

--- a/.github/workflows/update-changelog-docs-page.yml
+++ b/.github/workflows/update-changelog-docs-page.yml
@@ -1,5 +1,5 @@
 # This workflow will update the CHANGELOG page in the `bucketeer-io/bucketeer-docs` repository when a tag is created
-name: update-changelog-docs-page
+name: Update Changelog Docs Page
 
 on:
   workflow_dispatch:
@@ -24,7 +24,7 @@ jobs:
         id: commit_url
         run: echo "value=$(echo '${{ github.event.head_commit.url }}' | head -n 1)" >> $GITHUB_OUTPUT
 
-  update_changelog_doc_page:
+  update-changelog-doc-page:
     needs: setup
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/update-changelog-docs-page.yml
+++ b/.github/workflows/update-changelog-docs-page.yml
@@ -14,7 +14,7 @@ jobs:
       RELEASE_TAG: ${{ steps.release_tag.outputs.value }}
       COMMIT_URL: ${{ steps.commit_url.outputs.value }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
         with:
           fetch-depth: 0
       - name: Store the tag value
@@ -28,7 +28,7 @@ jobs:
     needs: setup
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
       - name: Workflow Dispatch
         uses: benc-uk/workflow-dispatch@798e70c97009500150087d30d9f11c5444830385 # v1.2.2
         env:

--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   upload-xcframework:
-    runs-on: macos-15-xlarge
+    runs-on: macos-14-xlarge
     env:
       MINT_PATH: ${{ github.workspace }}/mint/lib
       MINT_LINK_PATH: ${{ github.workspace }}/mint/bin

--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -13,7 +13,7 @@ jobs:
       MINT_PATH: ${{ github.workspace }}/mint/lib
       MINT_LINK_PATH: ${{ github.workspace }}/mint/bin
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
 
       - name: Install bootstrap mint
         uses: irgaly/setup-mint@99eaad2ad1197ea872390322a47620da2f21fde4 # v1.4.0

--- a/Mintfile
+++ b/Mintfile
@@ -1,3 +1,3 @@
 realm/SwiftLint@0.53.0
-yonaskolb/xcodegen@2.38.0
+yonaskolb/xcodegen@2.44.1
 bloomberg/xcdiff@0.11.0

--- a/README.md
+++ b/README.md
@@ -13,14 +13,14 @@ Minimum build tool versions:
 | Tool  | Version |
 | ----- | ------- |
 | Xcode | 13.1+   |
-| Swift | 5.0+    |
+| Swift | 5.3+    |
 
 Minimum device platforms:
 
 | Platform | Version |
 | -------- | ------- |
-| iOS      | 11.0    |
-| tvOS     | 11.0    |
+| iOS      | 12.0    |
+| tvOS     | 12.0    |
 
 ## Installation
 

--- a/project.yml
+++ b/project.yml
@@ -119,8 +119,7 @@ settings:
 packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
-    from: 10.18.0
-    upToNextMajorVersion: 11.0.0
+    from: 12.1.0
 targets:
   Bucketeer:
     platform: iOS

--- a/project.yml
+++ b/project.yml
@@ -1,6 +1,6 @@
 attributes:
-  LastSwiftUpdateCheck: '1420'
-  LastUpgradeCheck: '0930'
+  LastSwiftUpdateCheck: "1420"
+  LastUpgradeCheck: "0930"
   ORGANIZATIONNAME: Bucketeer
 configs:
   Debug: debug
@@ -19,11 +19,11 @@ schemes:
     build:
       targets:
         Bucketeer:
-        - running
-        - testing
-        - profiling
-        - analyzing
-        - archiving
+          - running
+          - testing
+          - profiling
+          - analyzing
+          - archiving
     profile:
       config: Release
     run:
@@ -31,12 +31,12 @@ schemes:
     test:
       config: Debug
       environmentVariables:
-      - value: $(E2E_API_ENDPOINT)
-        variable: E2E_API_ENDPOINT
-      - value: $(E2E_API_KEY)
-        variable: E2E_API_KEY
+        - value: $(E2E_API_ENDPOINT)
+          variable: E2E_API_ENDPOINT
+        - value: $(E2E_API_KEY)
+          variable: E2E_API_KEY
       targets:
-      - BucketeerTests
+        - BucketeerTests
   Example:
     analyze:
       config: Debug
@@ -45,11 +45,11 @@ schemes:
     build:
       targets:
         Example:
-        - running
-        - testing
-        - profiling
-        - analyzing
-        - archiving
+          - running
+          - testing
+          - profiling
+          - analyzing
+          - archiving
     profile:
       config: Release
     run:
@@ -64,11 +64,11 @@ schemes:
     build:
       targets:
         ExampleSwiftUI:
-        - running
-        - testing
-        - profiling
-        - analyzing
-        - archiving
+          - running
+          - testing
+          - profiling
+          - analyzing
+          - archiving
     profile:
       config: Release
     run:
@@ -83,11 +83,11 @@ schemes:
     build:
       targets:
         ExampleTVOS:
-        - running
-        - testing
-        - profiling
-        - analyzing
-        - archiving
+          - running
+          - testing
+          - profiling
+          - analyzing
+          - archiving
     profile:
       config: Release
     run:
@@ -98,24 +98,24 @@ settings:
   configs:
     Debug:
       CODE_SIGN_IDENTITY: iOS Developer
-      CURRENT_PROJECT_VERSION: '1'
-      IPHONEOS_DEPLOYMENT_TARGET: '10.0'
+      CURRENT_PROJECT_VERSION: "1"
+      IPHONEOS_DEPLOYMENT_TARGET: "11.0"
       SDKROOT: iphoneos
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
       SWIFT_OPTIMIZATION_LEVEL: -Onone
-      SWIFT_VERSION: '5.0'
+      SWIFT_VERSION: "5.0"
       VERSIONING_SYSTEM: apple-generic
-      VERSION_INFO_PREFIX: ''
+      VERSION_INFO_PREFIX: ""
     Release:
       CODE_SIGN_IDENTITY: iOS Developer
-      CURRENT_PROJECT_VERSION: '1'
-      IPHONEOS_DEPLOYMENT_TARGET: '10.0'
+      CURRENT_PROJECT_VERSION: "1"
+      IPHONEOS_DEPLOYMENT_TARGET: "11.0"
       SDKROOT: iphoneos
       SWIFT_OPTIMIZATION_LEVEL: -O
-      SWIFT_VERSION: '5.0'
+      SWIFT_VERSION: "5.0"
       VERSIONING_SYSTEM: apple-generic
-      VERSION_INFO_PREFIX: ''
-      VALIDATE_PRODUCT: 'YES'
+      VERSION_INFO_PREFIX: ""
+      VALIDATE_PRODUCT: "YES"
 packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
@@ -124,99 +124,100 @@ targets:
   Bucketeer:
     platform: iOS
     postbuildScripts:
-    - name: Run Script(linter)
-      runOnlyWhenInstalling: false
-      script: "#Run this script if not in a CI environment or Carthage build.\nif
-        [ -n $CI ] && [ \"$CI\" = \"true\" ]; then\n  echo \"Run this script if not
-        in a CI environment.\"\n  exit 0\nelif [ -n \"$CARTHAGE\" ]; then\n  echo
-        \"Run this script if not in Carthage build.\"\n  exit 0\nfi\n\n#Workaround:
-        Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export
-        PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which
-        mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is not
-        installed. Please run make install-mint.\"\nfi\n"
-      shell: /bin/sh
+      - name: Run Script(linter)
+        runOnlyWhenInstalling: false
+        script:
+          "#Run this script if not in a CI environment or Carthage build.\nif
+          [ -n $CI ] && [ \"$CI\" = \"true\" ]; then\n  echo \"Run this script if not
+          in a CI environment.\"\n  exit 0\nelif [ -n \"$CARTHAGE\" ]; then\n  echo
+          \"Run this script if not in Carthage build.\"\n  exit 0\nfi\n\n#Workaround:
+          Add Homebrew Path for M1 Mac.\nif [ $(uname -m) = \"arm64\" ]; then\n  export
+          PATH=\"/opt/homebrew/bin:/opt/homebrew/sbin:${PATH+:$PATH}\";\nfi\n\nif which
+          mint >/dev/null; then\n  make run-lint\nelse\n  echo \"Warning: Mint is not
+          installed. Please run make install-mint.\"\nfi\n"
+        shell: /bin/sh
     productName: Bucketeer
     settings:
       configs:
         Debug:
           CODE_SIGN_IDENTITY: iOS Developer
-          BUILD_LIBRARY_FOR_DISTRIBUTION: 'YES'
+          BUILD_LIBRARY_FOR_DISTRIBUTION: "YES"
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
           INFOPLIST_FILE: Bucketeer/Info.plist
-          IPHONEOS_DEPLOYMENT_TARGET: '11.0'
-          IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: '13.1'
+          IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+          IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: "13.1"
           MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
-          MTL_FAST_MATH: 'YES'
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios
           SUPPORTED_PLATFORMS: appletvos appletvsimulator iphoneos iphonesimulator
-          SUPPORTS_MACCATALYST: 'YES'
-          SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: 'YES'
-          SWIFT_EMIT_LOC_STRINGS: 'YES'
-          SWIFT_VERSION: '5.0'
+          SUPPORTS_MACCATALYST: "YES"
+          SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "YES"
+          SWIFT_EMIT_LOC_STRINGS: "YES"
+          SWIFT_VERSION: "5.0"
           TARGETED_DEVICE_FAMILY: 1,2,3
-          TVOS_DEPLOYMENT_TARGET: '11.0'
+          TVOS_DEPLOYMENT_TARGET: "11.0"
           LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @loader_path/Frameworks"
         Release:
           CODE_SIGN_IDENTITY: iOS Developer
-          BUILD_LIBRARY_FOR_DISTRIBUTION: 'YES'
+          BUILD_LIBRARY_FOR_DISTRIBUTION: "YES"
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
           INFOPLIST_FILE: Bucketeer/Info.plist
-          IPHONEOS_DEPLOYMENT_TARGET: '11.0'
-          IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: '13.1'
-          MTL_FAST_MATH: 'YES'
+          IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+          IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: "13.1"
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios
           SUPPORTED_PLATFORMS: appletvos appletvsimulator iphoneos iphonesimulator
-          SUPPORTS_MACCATALYST: 'YES'
-          SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: 'YES'
-          SWIFT_EMIT_LOC_STRINGS: 'YES'
-          SWIFT_VERSION: '5.0'
+          SUPPORTS_MACCATALYST: "YES"
+          SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "YES"
+          SWIFT_EMIT_LOC_STRINGS: "YES"
+          SWIFT_VERSION: "5.0"
           TARGETED_DEVICE_FAMILY: 1,2,3
-          TVOS_DEPLOYMENT_TARGET: '11.0'
+          TVOS_DEPLOYMENT_TARGET: "11.0"
           LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @loader_path/Frameworks"
     sources:
-    - name: Bucketeer
-      path: Bucketeer
+      - name: Bucketeer
+        path: Bucketeer
     type: framework
   BucketeerTests:
     dependencies:
-    - target: Bucketeer
-      embed: false
+      - target: Bucketeer
+        embed: false
     platform: iOS
     productName: BucketeerTests
     settings:
       configs:
         Debug:
-          ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: 'YES'
+          ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: "YES"
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
-          CURRENT_PROJECT_VERSION: '1'
-          GENERATE_INFOPLIST_FILE: 'YES'
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
-          IPHONEOS_DEPLOYMENT_TARGET: '15.5'
-          MARKETING_VERSION: '1.0'
+          CURRENT_PROJECT_VERSION: "1"
+          GENERATE_INFOPLIST_FILE: "YES"
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
+          IPHONEOS_DEPLOYMENT_TARGET: "15.5"
+          MARKETING_VERSION: "1.0"
           MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
-          MTL_FAST_MATH: 'YES'
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.tests
-          SWIFT_EMIT_LOC_STRINGS: 'NO'
-          SWIFT_VERSION: '5.0'
+          SWIFT_EMIT_LOC_STRINGS: "NO"
+          SWIFT_VERSION: "5.0"
         Release:
-          ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: 'YES'
+          ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: "YES"
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
-          CURRENT_PROJECT_VERSION: '1'
-          GENERATE_INFOPLIST_FILE: 'YES'
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
-          IPHONEOS_DEPLOYMENT_TARGET: '15.5'
-          MARKETING_VERSION: '1.0'
-          MTL_FAST_MATH: 'YES'
+          CURRENT_PROJECT_VERSION: "1"
+          GENERATE_INFOPLIST_FILE: "YES"
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
+          IPHONEOS_DEPLOYMENT_TARGET: "15.5"
+          MARKETING_VERSION: "1.0"
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.tests
-          SWIFT_EMIT_LOC_STRINGS: 'NO'
-          SWIFT_VERSION: '5.0'
+          SWIFT_EMIT_LOC_STRINGS: "NO"
+          SWIFT_VERSION: "5.0"
     sources:
-    - name: BucketeerTests
-      path: BucketeerTests
+      - name: BucketeerTests
+        path: BucketeerTests
     type: bundle.unit-test
   Example:
     entitlements:
@@ -224,9 +225,9 @@ targets:
       properties:
         aps-environment: development
     dependencies:
-    - target: Bucketeer
-    - package: Firebase
-      product: FirebaseMessaging
+      - target: Bucketeer
+      - package: Firebase
+        product: FirebaseMessaging
     platform: iOS
     configFiles:
       Debug: environment.xcconfig
@@ -235,47 +236,51 @@ targets:
         Debug:
           CODE_SIGN_IDENTITY: Apple Development
           CODE_SIGN_STYLE: Automatic
-          GENERATE_INFOPLIST_FILE: 'NO'
+          GENERATE_INFOPLIST_FILE: "NO"
           INFOPLIST_FILE: Example/Info.plist
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
           INFOPLIST_KEY_UILaunchStoryboardName: LaunchScreen
           INFOPLIST_KEY_UIMainStoryboardFile: Main
           INFOPLIST_KEY_UIRequiredDeviceCapabilities: armv7
-          INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
+          INFOPLIST_KEY_UISupportedInterfaceOrientations:
+            UIInterfaceOrientationPortrait
             UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait
+          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+            UIInterfaceOrientationPortrait
             UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationLandscapeRight
-          IPHONEOS_DEPLOYMENT_TARGET: '11.0'
-          MTL_ENABLE_DEBUG_INFO: 'YES'
+          IPHONEOS_DEPLOYMENT_TARGET: "12.0"
+          MTL_ENABLE_DEBUG_INFO: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
-          PROVISIONING_PROFILE_SPECIFIER: ''
-          SWIFT_VERSION: '5.0'
+          PROVISIONING_PROFILE_SPECIFIER: ""
+          SWIFT_VERSION: "5.0"
         Release:
           CODE_SIGN_IDENTITY: Apple Development
           CODE_SIGN_STYLE: Automatic
-          GENERATE_INFOPLIST_FILE: 'NO'
+          GENERATE_INFOPLIST_FILE: "NO"
           INFOPLIST_FILE: Example/Info.plist
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
           INFOPLIST_KEY_UILaunchStoryboardName: LaunchScreen
           INFOPLIST_KEY_UIMainStoryboardFile: Main
           INFOPLIST_KEY_UIRequiredDeviceCapabilities: armv7
-          INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationPortrait
+          INFOPLIST_KEY_UISupportedInterfaceOrientations:
+            UIInterfaceOrientationPortrait
             UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
-          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait
+          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+            UIInterfaceOrientationPortrait
             UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationLandscapeRight
-          IPHONEOS_DEPLOYMENT_TARGET: '11.0'
+          IPHONEOS_DEPLOYMENT_TARGET: "12.0"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
-          PROVISIONING_PROFILE_SPECIFIER: ''
-          SWIFT_VERSION: '5.0'
+          PROVISIONING_PROFILE_SPECIFIER: ""
+          SWIFT_VERSION: "5.0"
     sources:
-    - name: Example
-      path: Example
+      - name: Example
+        path: Example
     type: application
   ExampleSwiftUI:
     dependencies:
-    - target: Bucketeer
+      - target: Bucketeer
     platform: iOS
     configFiles:
       Debug: environment.xcconfig
@@ -286,55 +291,59 @@ targets:
           ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
           CLANG_CXX_LANGUAGE_STANDARD: gnu++20
           CODE_SIGN_STYLE: Automatic
-          CURRENT_PROJECT_VERSION: '1'
+          CURRENT_PROJECT_VERSION: "1"
           DEVELOPMENT_ASSET_PATHS: '"ExampleSwiftUI/Preview Content"'
-          GENERATE_INFOPLIST_FILE: 'YES'
+          GENERATE_INFOPLIST_FILE: "YES"
           INFOPLIST_FILE: ExampleSwiftUI/Info.plist
-          INFOPLIST_KEY_UIApplicationSceneManifest_Generation: 'YES'
-          INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: 'YES'
-          INFOPLIST_KEY_UILaunchScreen_Generation: 'YES'
-          INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationLandscapeLeft
+          INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"
+          INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: "YES"
+          INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+          INFOPLIST_KEY_UISupportedInterfaceOrientations:
+            UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationPortrait
-          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationLandscapeLeft
+          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+            UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown
-          IPHONEOS_DEPLOYMENT_TARGET: '14.0'
-          MARKETING_VERSION: '1.0'
+          IPHONEOS_DEPLOYMENT_TARGET: "14.0"
+          MARKETING_VERSION: "1.0"
           MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
-          MTL_FAST_MATH: 'YES'
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.ExampleSwiftUI
-          SWIFT_EMIT_LOC_STRINGS: 'YES'
-          SWIFT_VERSION: '5.0'
-          ENABLE_PREVIEWS: 'YES'
+          SWIFT_EMIT_LOC_STRINGS: "YES"
+          SWIFT_VERSION: "5.0"
+          ENABLE_PREVIEWS: "YES"
         Release:
           ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
           CLANG_CXX_LANGUAGE_STANDARD: gnu++20
           CODE_SIGN_STYLE: Automatic
-          CURRENT_PROJECT_VERSION: '1'
+          CURRENT_PROJECT_VERSION: "1"
           DEVELOPMENT_ASSET_PATHS: '"ExampleSwiftUI/Preview Content"'
-          GENERATE_INFOPLIST_FILE: 'YES'
+          GENERATE_INFOPLIST_FILE: "YES"
           INFOPLIST_FILE: ExampleSwiftUI/Info.plist
-          INFOPLIST_KEY_UIApplicationSceneManifest_Generation: 'YES'
-          INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: 'YES'
-          INFOPLIST_KEY_UILaunchScreen_Generation: 'YES'
-          INFOPLIST_KEY_UISupportedInterfaceOrientations: UIInterfaceOrientationLandscapeLeft
+          INFOPLIST_KEY_UIApplicationSceneManifest_Generation: "YES"
+          INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents: "YES"
+          INFOPLIST_KEY_UILaunchScreen_Generation: "YES"
+          INFOPLIST_KEY_UISupportedInterfaceOrientations:
+            UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationPortrait
-          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationLandscapeLeft
+          INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+            UIInterfaceOrientationLandscapeLeft
             UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown
-          IPHONEOS_DEPLOYMENT_TARGET: '14.0'
-          MARKETING_VERSION: '1.0'
-          MTL_FAST_MATH: 'YES'
+          IPHONEOS_DEPLOYMENT_TARGET: "14.0"
+          MARKETING_VERSION: "1.0"
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.ExampleSwiftUI
-          SWIFT_EMIT_LOC_STRINGS: 'YES'
-          SWIFT_VERSION: '5.0'
-          ENABLE_PREVIEWS: 'YES'
+          SWIFT_EMIT_LOC_STRINGS: "YES"
+          SWIFT_VERSION: "5.0"
+          ENABLE_PREVIEWS: "YES"
     sources:
-    - name: ExampleSwiftUI
-      path: ExampleSwiftUI
+      - name: ExampleSwiftUI
+        path: ExampleSwiftUI
     type: application
   ExampleTVOS:
     dependencies:
-    - target: Bucketeer
-      embed: false
+      - target: Bucketeer
+        embed: false
     platform: iOS
     configFiles:
       Debug: environment.xcconfig
@@ -344,32 +353,32 @@ targets:
           ASSETCATALOG_COMPILER_APPICON_NAME: App Icon & Top Shelf Image
           CODE_SIGN_STYLE: Automatic
           DEVELOPMENT_ASSET_PATHS: '"ExampleTVOS/Preview Content"'
-          GENERATE_INFOPLIST_FILE: 'YES'
+          GENERATE_INFOPLIST_FILE: "YES"
           INFOPLIST_FILE: ExampleTVOS/Info.plist
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
           MARKETING_VERSION: 0.0.1
           MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
-          MTL_FAST_MATH: 'YES'
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.tvos.example
           SDKROOT: appletvos
-          SWIFT_VERSION: '5.0'
-          TARGETED_DEVICE_FAMILY: '3'
-          TVOS_DEPLOYMENT_TARGET: '11.0'
+          SWIFT_VERSION: "5.0"
+          TARGETED_DEVICE_FAMILY: "3"
+          TVOS_DEPLOYMENT_TARGET: "11.0"
         Release:
           ASSETCATALOG_COMPILER_APPICON_NAME: App Icon & Top Shelf Image
           CODE_SIGN_STYLE: Automatic
           DEVELOPMENT_ASSET_PATHS: '"ExampleTVOS/Preview Content"'
-          GENERATE_INFOPLIST_FILE: 'YES'
+          GENERATE_INFOPLIST_FILE: "YES"
           INFOPLIST_FILE: ExampleTVOS/Info.plist
-          INFOPLIST_KEY_LSApplicationCategoryType: ''
+          INFOPLIST_KEY_LSApplicationCategoryType: ""
           MARKETING_VERSION: 0.0.1
-          MTL_FAST_MATH: 'YES'
+          MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.tvos.example
           SDKROOT: appletvos
-          SWIFT_VERSION: '5.0'
-          TARGETED_DEVICE_FAMILY: '3'
-          TVOS_DEPLOYMENT_TARGET: '11.0'
+          SWIFT_VERSION: "5.0"
+          TARGETED_DEVICE_FAMILY: "3"
+          TVOS_DEPLOYMENT_TARGET: "11.0"
     sources:
-    - name: ExampleTVOS
-      path: ExampleTVOS
+      - name: ExampleTVOS
+        path: ExampleTVOS
     type: application

--- a/project.yml
+++ b/project.yml
@@ -255,10 +255,6 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
           PROVISIONING_PROFILE_SPECIFIER: ""
           SWIFT_VERSION: "5.3"
-          SWIFT_OPTIMIZATION_LEVEL: -Onone
-          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
-          CLANG_ENABLE_MODULES: "YES"
-          SWIFT_ENABLE_BATCH_MODE: "NO"
         Release:
           CODE_SIGN_IDENTITY: Apple Development
           CODE_SIGN_STYLE: Automatic
@@ -279,9 +275,6 @@ targets:
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
           PROVISIONING_PROFILE_SPECIFIER: ""
           SWIFT_VERSION: "5.3"
-          SWIFT_OPTIMIZATION_LEVEL: -O
-          CLANG_ENABLE_MODULES: "YES"
-          SWIFT_ENABLE_BATCH_MODE: "NO"
     sources:
       - name: Example
         path: Example

--- a/project.yml
+++ b/project.yml
@@ -99,27 +99,28 @@ settings:
     Debug:
       CODE_SIGN_IDENTITY: iOS Developer
       CURRENT_PROJECT_VERSION: "1"
-      IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+      IPHONEOS_DEPLOYMENT_TARGET: "12.0"
       SDKROOT: iphoneos
       SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
       SWIFT_OPTIMIZATION_LEVEL: -Onone
-      SWIFT_VERSION: "5.0"
+      SWIFT_VERSION: "5.3"
       VERSIONING_SYSTEM: apple-generic
       VERSION_INFO_PREFIX: ""
     Release:
       CODE_SIGN_IDENTITY: iOS Developer
       CURRENT_PROJECT_VERSION: "1"
-      IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+      IPHONEOS_DEPLOYMENT_TARGET: "12.0"
       SDKROOT: iphoneos
       SWIFT_OPTIMIZATION_LEVEL: -O
-      SWIFT_VERSION: "5.0"
+      SWIFT_VERSION: "5.3"
       VERSIONING_SYSTEM: apple-generic
       VERSION_INFO_PREFIX: ""
       VALIDATE_PRODUCT: "YES"
 packages:
   Firebase:
     url: https://github.com/firebase/firebase-ios-sdk
-    from: 11.1.0
+    from: 10.18.0
+    upToNextMajorVersion: 11.0.0
 targets:
   Bucketeer:
     platform: iOS
@@ -145,7 +146,7 @@ targets:
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
           INFOPLIST_FILE: Bucketeer/Info.plist
-          IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+          IPHONEOS_DEPLOYMENT_TARGET: "12.0"
           IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: "13.1"
           MTL_ENABLE_DEBUG_INFO: INCLUDE_SOURCE
           MTL_FAST_MATH: "YES"
@@ -154,9 +155,9 @@ targets:
           SUPPORTS_MACCATALYST: "YES"
           SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "YES"
           SWIFT_EMIT_LOC_STRINGS: "YES"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           TARGETED_DEVICE_FAMILY: 1,2,3
-          TVOS_DEPLOYMENT_TARGET: "11.0"
+          TVOS_DEPLOYMENT_TARGET: "12.0"
           LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @loader_path/Frameworks"
         Release:
           CODE_SIGN_IDENTITY: iOS Developer
@@ -164,7 +165,7 @@ targets:
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
           CODE_SIGN_STYLE: Automatic
           INFOPLIST_FILE: Bucketeer/Info.plist
-          IPHONEOS_DEPLOYMENT_TARGET: "11.0"
+          IPHONEOS_DEPLOYMENT_TARGET: "12.0"
           IPHONEOS_DEPLOYMENT_TARGET[sdk=macosx*]: "13.1"
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios
@@ -172,9 +173,9 @@ targets:
           SUPPORTS_MACCATALYST: "YES"
           SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD: "YES"
           SWIFT_EMIT_LOC_STRINGS: "YES"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           TARGETED_DEVICE_FAMILY: 1,2,3
-          TVOS_DEPLOYMENT_TARGET: "11.0"
+          TVOS_DEPLOYMENT_TARGET: "12.0"
           LD_RUNPATH_SEARCH_PATHS: "$(inherited) @executable_path/Frameworks @loader_path/Frameworks"
     sources:
       - name: Bucketeer
@@ -201,7 +202,7 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.tests
           SWIFT_EMIT_LOC_STRINGS: "NO"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
         Release:
           ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: "YES"
           CLANG_CXX_LANGUAGE_STANDARD: gnu++17
@@ -214,7 +215,7 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.tests
           SWIFT_EMIT_LOC_STRINGS: "NO"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
     sources:
       - name: BucketeerTests
         path: BucketeerTests
@@ -253,7 +254,11 @@ targets:
           MTL_ENABLE_DEBUG_INFO: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
           PROVISIONING_PROFILE_SPECIFIER: ""
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
+          SWIFT_OPTIMIZATION_LEVEL: -Onone
+          SWIFT_ACTIVE_COMPILATION_CONDITIONS: DEBUG
+          CLANG_ENABLE_MODULES: "YES"
+          SWIFT_ENABLE_BATCH_MODE: "NO"
         Release:
           CODE_SIGN_IDENTITY: Apple Development
           CODE_SIGN_STYLE: Automatic
@@ -273,7 +278,10 @@ targets:
           IPHONEOS_DEPLOYMENT_TARGET: "12.0"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.example
           PROVISIONING_PROFILE_SPECIFIER: ""
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
+          SWIFT_OPTIMIZATION_LEVEL: -O
+          CLANG_ENABLE_MODULES: "YES"
+          SWIFT_ENABLE_BATCH_MODE: "NO"
     sources:
       - name: Example
         path: Example
@@ -310,7 +318,7 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.ExampleSwiftUI
           SWIFT_EMIT_LOC_STRINGS: "YES"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           ENABLE_PREVIEWS: "YES"
         Release:
           ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME: AccentColor
@@ -334,7 +342,7 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.ios.ExampleSwiftUI
           SWIFT_EMIT_LOC_STRINGS: "YES"
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           ENABLE_PREVIEWS: "YES"
     sources:
       - name: ExampleSwiftUI
@@ -361,9 +369,9 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.tvos.example
           SDKROOT: appletvos
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           TARGETED_DEVICE_FAMILY: "3"
-          TVOS_DEPLOYMENT_TARGET: "11.0"
+          TVOS_DEPLOYMENT_TARGET: "12.0"
         Release:
           ASSETCATALOG_COMPILER_APPICON_NAME: App Icon & Top Shelf Image
           CODE_SIGN_STYLE: Automatic
@@ -375,9 +383,9 @@ targets:
           MTL_FAST_MATH: "YES"
           PRODUCT_BUNDLE_IDENTIFIER: io.bucketeer.sdk.tvos.example
           SDKROOT: appletvos
-          SWIFT_VERSION: "5.0"
+          SWIFT_VERSION: "5.3"
           TARGETED_DEVICE_FAMILY: "3"
-          TVOS_DEPLOYMENT_TARGET: "11.0"
+          TVOS_DEPLOYMENT_TARGET: "12.0"
     sources:
       - name: ExampleTVOS
         path: ExampleTVOS


### PR DESCRIPTION
Fix https://github.com/bucketeer-io/ios-client-sdk/issues/109

### Things done

- Fixed the unable to find a destination matching the provided destination specifier error by downgrading from macos-15-xlarge to macos-14-xlarge for better compatibility
- Changed the minimum development target version from 11.0  to 12.0 (Needed when using macos-14 with Firebase)
- Updated the minimum Swift version from 5.0 to 5.3
- Updated mint to 2.44.1
- Updated README

### CI results:
[Pull request](https://github.com/bucketeer-io/ios-client-sdk/actions/runs/17088340127)
[Build & Integration tests](https://github.com/bucketeer-io/ios-client-sdk/actions/runs/17088184274) 
