### PR TITLE
refactor: simplified network error detection by checking only the NSURLErrorDomain

### DIFF
--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -145,10 +145,12 @@ final class ApiClientImpl: ApiClient {
             var result : Result<(Response, URLResponse), Error>?
             let responseParser : (Data?, URLResponse?, Error?) -> Result<(Response, URLResponse), Error> = { data, urlResponse, error in
                 guard let urlResponse = urlResponse as? HTTPURLResponse else {
-                    // error is not from server
+                    // urlResponse == nil that mean error is not from server
                     guard let error = error else {
+                        // error is unknown
                         return .failure(ResponseError.unknown(urlResponse))
                     }
+                    // a NSError with NSURLErrorDomain codes
                     return .failure(error)
                 }
 

--- a/Bucketeer/Sources/Public/BKTError.swift
+++ b/Bucketeer/Sources/Public/BKTError.swift
@@ -107,16 +107,17 @@ extension BKTError : LocalizedError {
             }
             return
         }
-
+        // This bridging is available where the Objective-C runtime is available (iOS)
+        // https://github.com/swiftlang/swift-evolution/blob/main/proposals/0112-nserror-bridging.md
         let nsError = error as NSError
+        // Any error with Error Domain = NSURLErrorDomain can be considered a network error.
+        // https://developer.apple.com/documentation/foundation/nsurlerrordomain
         if nsError.domain == NSURLErrorDomain {
             let nsErrorCode = nsError.code
-            if BKTError.networkErrorCodes.contains(nsErrorCode) {
-                self = .network(message: "Network connection error: \(error)", error: error)
-            } else if nsErrorCode == NSURLErrorTimedOut {
+            if nsErrorCode == NSURLErrorTimedOut {
                 self = .timeout(message: "Request timeout error: \(error)", error: error, timeoutMillis: 0)
             } else {
-                self = .unknown(message: "Unknown error: \(error)", error: error)
+                self = .network(message: "Network connection error: \(error)", error: error)
             }
         } else {
             self = .unknown(message: "Unknown error: \(error)", error: error)
@@ -194,36 +195,4 @@ extension BKTError : LocalizedError {
             return "\(error)"
         }
     }
-}
-
-extension BKTError {
-    // full list of NSURLError  https://developer.apple.com/documentation/foundation/nserror/1448136-nserror_codes#3139076
-    static let networkErrorCodes = [
-        NSURLErrorBadURL,
-        NSURLErrorUnsupportedURL,
-        NSURLErrorNotConnectedToInternet,
-        NSURLErrorNetworkConnectionLost,
-        NSURLErrorCannotFindHost,
-        NSURLErrorCannotConnectToHost,
-        NSURLErrorDNSLookupFailed,
-        // Router, gateway error
-        NSURLErrorHTTPTooManyRedirects,
-        NSURLErrorRedirectToNonExistentLocation,
-        // SSL error
-        NSURLErrorAppTransportSecurityRequiresSecureConnection,
-        NSURLErrorSecureConnectionFailed,
-        NSURLErrorServerCertificateHasBadDate,
-        NSURLErrorServerCertificateUntrusted,
-        NSURLErrorServerCertificateHasUnknownRoot,
-        NSURLErrorServerCertificateNotYetValid,
-        NSURLErrorClientCertificateRejected,
-        NSURLErrorClientCertificateRequired,
-        // Data network errors 3G,4G...
-        NSURLErrorResourceUnavailable,
-        NSURLErrorCannotLoadFromNetwork,
-        NSURLErrorInternationalRoamingOff,
-        NSURLErrorCallIsActive,
-        NSURLErrorDataNotAllowed,
-        NSURLErrorRequestBodyStreamExhausted
-    ]
 }

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -231,7 +231,7 @@ class BKTErrorTests: XCTestCase {
             .timeout(message: "Request timeout error: \(timeoutError)", error: timeoutError, timeoutMillis: 0)
         )
 
-        for networkErrorCode in BKTError.networkErrorCodes {
+        for networkErrorCode in BKTError.testNetworkErrorCodes {
             let networkError = NSError(domain: NSURLErrorDomain, code: networkErrorCode, userInfo: [:])
             assertEqual(
                 .init(error: networkError),
@@ -343,7 +343,7 @@ class BKTErrorTests: XCTestCase {
     }
 }
 
-extension BKTError: CaseIterable {
+extension BKTError {
 
     public enum TestError: Error {
         case timeout
@@ -369,6 +369,38 @@ extension BKTError: CaseIterable {
         .invalidHttpMethod(message: "invalidHttpMethod"),
         .unknownServer(message: "unknownServer", error: TestError.unknownServer, statusCode: 450),
         .unknown(message: "unknown", error: TestError.unknown)
+    ]
+
+    // full list of NSURLError  https://developer.apple.com/documentation/foundation/nserror/1448136-nserror_codes#3139076
+    static let testNetworkErrorCodes = [
+        NSURLErrorBadURL,
+        NSURLErrorUnsupportedURL,
+        NSURLErrorNotConnectedToInternet,
+        NSURLErrorNetworkConnectionLost,
+        NSURLErrorCannotFindHost,
+        NSURLErrorCannotConnectToHost,
+        NSURLErrorDNSLookupFailed,
+        // Router, gateway error
+        NSURLErrorHTTPTooManyRedirects,
+        NSURLErrorRedirectToNonExistentLocation,
+        // SSL error
+        NSURLErrorAppTransportSecurityRequiresSecureConnection,
+        NSURLErrorSecureConnectionFailed,
+        NSURLErrorServerCertificateHasBadDate,
+        NSURLErrorServerCertificateUntrusted,
+        NSURLErrorServerCertificateHasUnknownRoot,
+        NSURLErrorServerCertificateNotYetValid,
+        NSURLErrorClientCertificateRejected,
+        NSURLErrorClientCertificateRequired,
+        // Data network errors 3G,4G...
+        NSURLErrorResourceUnavailable,
+        NSURLErrorCannotLoadFromNetwork,
+        NSURLErrorInternationalRoamingOff,
+        NSURLErrorCallIsActive,
+        NSURLErrorDataNotAllowed,
+        NSURLErrorRequestBodyStreamExhausted,
+        // The connection can’t parse the server’s response.
+        NSURLErrorCannotParseResponse
     ]
 }
 // swiftlint:enable type_body_length


### PR DESCRIPTION
Simplified network error detection by checking only the NSURLErrorDomain and handling timeout errors separately. Moved the list of network error codes used for testing from BKTError to BKTErrorTests, and updated related test logic. Improved comments for clarity in error handling.