### PR TITLE
chore: allow to set wrapper SDK info (sourceId & version)

### DIFF
--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -27,7 +27,7 @@ final class ComponentImpl: Component {
             featureTag: dataModule.config.featureTag
         )
         self.eventInteractor = EventInteractorImpl(
-            sdkVersion: dataModule.config.sdkVersion,
+            sdkInfo: .init(sourceId: dataModule.config.sourceId, sdkVersion: dataModule.config.sdkVersion),
             appVersion: dataModule.config.appVersion,
             device: dataModule.device,
             eventsMaxBatchQueueCount: dataModule.config.eventsMaxQueueSize,

--- a/Bucketeer/Sources/Internal/DI/Component.swift
+++ b/Bucketeer/Sources/Internal/DI/Component.swift
@@ -27,7 +27,7 @@ final class ComponentImpl: Component {
             featureTag: dataModule.config.featureTag
         )
         self.eventInteractor = EventInteractorImpl(
-            sdkInfo: .init(sourceId: dataModule.config.sourceId, sdkVersion: dataModule.config.sdkVersion),
+            sdkInfo: dataModule.config.toSDKInfo(),
             appVersion: dataModule.config.appVersion,
             device: dataModule.device,
             eventsMaxBatchQueueCount: dataModule.config.eventsMaxQueueSize,

--- a/Bucketeer/Sources/Internal/DI/DataModule.swift
+++ b/Bucketeer/Sources/Internal/DI/DataModule.swift
@@ -33,7 +33,7 @@ final class DataModuleImpl: DataModule {
         apiEndpoint: config.apiEndpoint,
         apiKey: self.config.apiKey,
         featureTag: self.config.featureTag,
-        sdkInfo: .init(sourceId: self.config.sourceId, sdkVersion: self.config.sdkVersion),
+        sdkInfo: self.config.toSDKInfo(),
         session: URLSession(configuration: .default),
         logger: self.config.logger
     )

--- a/Bucketeer/Sources/Internal/DI/DataModule.swift
+++ b/Bucketeer/Sources/Internal/DI/DataModule.swift
@@ -33,6 +33,7 @@ final class DataModuleImpl: DataModule {
         apiEndpoint: config.apiEndpoint,
         apiKey: self.config.apiKey,
         featureTag: self.config.featureTag,
+        sdkInfo: .init(sourceId: self.config.sourceId, sdkVersion: self.config.sdkVersion),
         session: URLSession(configuration: .default),
         logger: self.config.logger
     )

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -193,8 +193,9 @@ final class EventInteractorImpl: EventInteractor {
             labels: ["tag": featureTag],
             currentTimeSeconds: clock.currentTimeSeconds,
             sdkInfo: sdkInfo,
-            metadata: metadata,
+            metadata: metadata
         )
+
         try trackMetricsEvent(events: [
             .init(
                 id: idGenerator.id(),

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -193,7 +193,7 @@ final class EventInteractorImpl: EventInteractor {
             labels: ["tag": featureTag],
             currentTimeSeconds: clock.currentTimeSeconds,
             sdkInfo: sdkInfo,
-            metadata: metadata
+            metadata: metadata,
         )
         try trackMetricsEvent(events: [
             .init(

--- a/Bucketeer/Sources/Internal/Event/EventInteractor.swift
+++ b/Bucketeer/Sources/Internal/Event/EventInteractor.swift
@@ -18,7 +18,7 @@ extension EventInteractor {
 }
 
 final class EventInteractorImpl: EventInteractor {
-    let sdkVersion: String
+    let sdkInfo: SDKInfo
     let eventsMaxBatchQueueCount: Int
     let apiClient: ApiClient
     let eventSQLDao: EventSQLDao
@@ -31,7 +31,7 @@ final class EventInteractorImpl: EventInteractor {
     private var eventUpdateListener: EventUpdateListener?
 
     init(
-        sdkVersion: String,
+        sdkInfo: SDKInfo,
         appVersion: String,
         device: Device,
         eventsMaxBatchQueueCount: Int,
@@ -42,7 +42,7 @@ final class EventInteractorImpl: EventInteractor {
         logger: Logger?,
         featureTag: String
     ) {
-        self.sdkVersion = sdkVersion
+        self.sdkInfo = sdkInfo
         self.eventsMaxBatchQueueCount = eventsMaxBatchQueueCount
         self.apiClient = apiClient
         self.eventSQLDao = eventSQLDao
@@ -75,8 +75,8 @@ final class EventInteractorImpl: EventInteractor {
                     user: user,
                     reason: evaluation.reason,
                     tag: featureTag,
-                    sourceId: .ios,
-                    sdkVersion: sdkVersion,
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: metadata
                 )),
                 type: .evaluation
@@ -96,8 +96,8 @@ final class EventInteractorImpl: EventInteractor {
                     user: user,
                     reason: .init(type: .client),
                     tag: featureTag,
-                    sourceId: .ios,
-                    sdkVersion: sdkVersion,
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: metadata
                 )),
                 type: .evaluation
@@ -117,8 +117,8 @@ final class EventInteractorImpl: EventInteractor {
                     value: value,
                     user: user,
                     tag: featureTag,
-                    sourceId: .ios,
-                    sdkVersion: sdkVersion,
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: metadata
                 )),
                 type: .goal
@@ -140,8 +140,8 @@ final class EventInteractorImpl: EventInteractor {
                             latencySecond: seconds
                         )),
                         type: .responseLatency,
-                        sourceId: .ios,
-                        sdk_version: sdkVersion,
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: metadata
                     )),
                     type: .metrics
@@ -156,8 +156,8 @@ final class EventInteractorImpl: EventInteractor {
                             sizeByte: sizeByte
                         )),
                         type: .responseSize,
-                        sourceId: .ios,
-                        sdk_version: sdkVersion,
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: metadata
                     )),
                     type: .metrics
@@ -192,7 +192,7 @@ final class EventInteractorImpl: EventInteractor {
             apiId: apiId,
             labels: ["tag": featureTag],
             currentTimeSeconds: clock.currentTimeSeconds,
-            sdkVersion: sdkVersion,
+            sdkInfo: sdkInfo,
             metadata: metadata
         )
         try trackMetricsEvent(events: [
@@ -332,8 +332,12 @@ extension Event {
 }
 
 extension BKTError {
-    func toMetricsEventData(apiId: ApiId, labels: [String: String], currentTimeSeconds: Int64, sdkVersion: String, metadata: [String: String]?) ->
-    EventData {
+    func toMetricsEventData(
+        apiId: ApiId,
+        labels: [String: String],
+        currentTimeSeconds: Int64,
+        sdkInfo: SDKInfo,
+        metadata: [String: String]?) -> EventData {
         let error = self
         let metricsEventData: MetricsEventData
         let metricsEventType: MetricsEventType
@@ -427,8 +431,8 @@ extension BKTError {
             timestamp: currentTimeSeconds,
             event: metricsEventData,
             type: metricsEventType,
-            sourceId: .ios,
-            sdk_version: sdkVersion,
+            sourceId: sdkInfo.sourceId,
+            sdk_version: sdkInfo.sdkVersion,
             metadata: metadata
         ))
     }

--- a/Bucketeer/Sources/Internal/Model/SDKInfo.swift
+++ b/Bucketeer/Sources/Internal/Model/SDKInfo.swift
@@ -1,0 +1,4 @@
+struct SDKInfo {
+   let sourceId: SourceID
+   let sdkVersion: String
+}

--- a/Bucketeer/Sources/Internal/Model/SourceID.swift
+++ b/Bucketeer/Sources/Internal/Model/SourceID.swift
@@ -8,4 +8,12 @@ enum SourceID: Int, Codable, Hashable {
     case goalBatch = 4
     case goServer = 5
     case nodeServer = 6
+    case flutter = 8
+    case react = 9
+    case reactNative = 10
+    case openFeatureKotlin = 100
+    case openFeatureSwift = 101
+    case openFeatureJavaScript = 102
+    case openFeatureGo = 103
+    case openFeatureNode = 104
 }

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -55,7 +55,7 @@ final class ApiClientImpl: ApiClient {
                 evaluatedAt: condition.evaluatedAt,
                 userAttributesUpdated: condition.userAttributesUpdated
             ),
-            sdkVersion: Version.current
+            sdkVersion: sdkInfo.sdkVersion
         )
         let featureTag = self.featureTag
         let timeoutMillisValue = timeoutMillis ?? defaultRequestTimeoutMills

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -85,7 +85,7 @@ final class ApiClientImpl: ApiClient {
         let requestBody = RegisterEventsRequestBody(
             events: events,
             sdkVersion: sdkInfo.sdkVersion,
-            sourceId: sdkInfo.sourceId,
+            sourceId: sdkInfo.sourceId
         )
         logger?.debug(message: "[API] Register events: \(requestBody)")
         let encoder = JSONEncoder()

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -24,7 +24,7 @@ final class ApiClientImpl: ApiClient {
         apiEndpoint: URL,
         apiKey: String,
         featureTag: String,
-        sdkInfo: SDKInfo = SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+        sdkInfo: SDKInfo,
         defaultRequestTimeoutMills: Int64 = ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS,
         session: Session,
         logger: Logger?

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -7,6 +7,7 @@ final class ApiClientImpl: ApiClient {
     private let apiEndpoint: URL
     private let apiKey: String
     private let featureTag: String
+    private let sdkInfo: SDKInfo
     private let session: Session
     private let defaultRequestTimeoutMills: Int64
     private let logger: Logger?
@@ -23,14 +24,15 @@ final class ApiClientImpl: ApiClient {
         apiEndpoint: URL,
         apiKey: String,
         featureTag: String,
+        sdkInfo: SDKInfo = SDKInfo(sourceId: .ios, sdkVersion: Version.current),
         defaultRequestTimeoutMills: Int64 = ApiClientImpl.DEFAULT_REQUEST_TIMEOUT_MILLIS,
         session: Session,
         logger: Logger?
     ) {
-
         self.apiEndpoint = apiEndpoint
         self.apiKey = apiKey
         self.featureTag = featureTag
+        self.sdkInfo = sdkInfo
         self.defaultRequestTimeoutMills = defaultRequestTimeoutMills
         self.session = session
         self.logger = logger
@@ -48,7 +50,7 @@ final class ApiClientImpl: ApiClient {
             tag: self.featureTag,
             user: user,
             userEvaluationsId: userEvaluationsId,
-            sourceId: .ios,
+            sourceId: sdkInfo.sourceId,
             userEvaluationCondition: UserEvaluationCondition(
                 evaluatedAt: condition.evaluatedAt,
                 userAttributesUpdated: condition.userAttributesUpdated
@@ -82,7 +84,8 @@ final class ApiClientImpl: ApiClient {
     func registerEvents(events: [Event], completion: ((Result<RegisterEventsResponse, BKTError>) -> Void)?) {
         let requestBody = RegisterEventsRequestBody(
             events: events,
-            sdkVersion: Version.current
+            sdkVersion: sdkInfo.sdkVersion,
+            sourceId: sdkInfo.sourceId,
         )
         logger?.debug(message: "[API] Register events: \(requestBody)")
         let encoder = JSONEncoder()

--- a/Bucketeer/Sources/Internal/Remote/RequestBody/RegisterEventsRequestBody.swift
+++ b/Bucketeer/Sources/Internal/Remote/RequestBody/RegisterEventsRequestBody.swift
@@ -2,8 +2,8 @@ import Foundation
 
 struct RegisterEventsRequestBody: Codable {
     internal init(events: [Event] = [],
-                  sdkVersion: String = Version.current,
-                  sourceId: SourceID = SourceID.ios
+                  sdkVersion: String,
+                  sourceId: SourceID
     ) {
         self.events = events
         self.sdkVersion = sdkVersion

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -188,6 +188,10 @@ extension BKTConfig {
         self.appVersion = appVersion
         self.logger = logger
     }
+
+    func toSDKInfo() -> SDKInfo {
+        return .init(sourceId: self.sourceId, sdkVersion: self.sdkVersion)
+    }
 }
 
 // Only Flutter (8) and OpenFeature Swift (101) are supported currently.

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -125,7 +125,7 @@ extension BKTConfig {
         guard let apiKey = builder.apiKey, apiKey.isNotEmpty() else {
             throw BKTError.illegalArgument(message: "apiKey is required")
         }
-        guard let apiEndpoint = builder.apiEndpoint, apiEndpoint.isNotEmpty() else {
+        guard let apiEndpoint = builder.apiEndpoint, apiEndpoint.isNotEmpty(), let apiEndpointURL = URL(string: apiEndpoint) else {
             throw BKTError.illegalArgument(message: "apiEndpoint is required")
         }
         guard let appVersion = builder.appVersion, appVersion.isNotEmpty() else {
@@ -133,7 +133,7 @@ extension BKTConfig {
         }
 
         // refs: JS SDK PR https://github.com/bucketeer-io/javascript-client-sdk/pull/91
-        // Allow Builder.featureTag could be nill
+        // Allow Builder.featureTag to be nil
         // So the default value of the BKTConfig will be ""
         let featureTag = builder.featureTag ?? ""
         let logger = builder.logger
@@ -142,16 +142,6 @@ extension BKTConfig {
         var backgroundPollingInterval: Int64 = builder.backgroundPollingInterval ?? Constant.MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS
         var eventsFlushInterval: Int64 = builder.eventsFlushInterval ?? Constant.DEFAULT_FLUSH_INTERVAL_MILLIS
         let eventsMaxQueueSize = builder.eventsMaxQueueSize ?? Constant.DEFAULT_MAX_QUEUE_SIZE
-
-        guard !apiKey.isEmpty else {
-            throw BKTError.illegalArgument(message: "apiKey is required")
-        }
-        guard let apiEndpointURL = URL(string: apiEndpoint) else {
-            throw BKTError.illegalArgument(message: "apiEndpoint is required")
-        }
-        guard !appVersion.isEmpty else {
-            throw BKTError.illegalArgument(message: "appVersion is required")
-        }
 
         if pollingInterval < Constant.MINIMUM_POLLING_INTERVAL_MILLIS {
             logger?.warn(message: "pollingInterval: \(pollingInterval) is set but must be above \(Constant.MINIMUM_POLLING_INTERVAL_MILLIS)")
@@ -177,7 +167,7 @@ extension BKTConfig {
 
         let resolvedSdkSourceId = try resolveSdkSourceId(wrapperSdkSourceId: builder.wrapperSdkSourceId)
         let resolvedSdkVersion = try resolveSdkVersion(
-            resolveSdkSourceId: resolvedSdkSourceId,
+            resolvedSdkSourceId: resolvedSdkSourceId,
             wrapperSdkVersion: builder.wrapperSdkVersion
         )
 
@@ -200,8 +190,8 @@ private func resolveSdkSourceId(wrapperSdkSourceId: Int?) throws -> SourceID {
     throw BKTError.illegalArgument(message: "Unsupported wrapperSdkSourceId: \(wrapperSdkSourceId)")
 }
 
-private func resolveSdkVersion(resolveSdkSourceId: SourceID, wrapperSdkVersion: String?) throws -> String {
-    if resolveSdkSourceId != .ios {
+private func resolveSdkVersion(resolvedSdkSourceId: SourceID, wrapperSdkVersion: String?) throws -> String {
+    if resolvedSdkSourceId != .ios {
         if let wrapperSdkVersion = wrapperSdkVersion, wrapperSdkVersion.isNotEmpty() {
             return wrapperSdkVersion
         }

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -190,11 +190,12 @@ extension BKTConfig {
     }
 }
 
+private let supportedWrapperSdkSourceIds: [SourceID] = [.flutter, .openFeatureSwift]
+
 private func resolveSdkSourceId(wrapperSdkSourceId: Int?) throws -> SourceID {
     guard let wrapperSdkSourceId = wrapperSdkSourceId else {
-        return .ios // native
+        return .ios // default ios
     }
-    // There is only one supported wrapperSdkSourceId (flutter) for now
     if let sourceId = SourceID(rawValue: wrapperSdkSourceId), supportedWrapperSdkSourceIds.contains(sourceId) {
         return sourceId
     }
@@ -210,8 +211,6 @@ private func resolveSdkVersion(resolveSdkSourceId: SourceID, wrapperSdkVersion: 
     }
     return Version.current
 }
-
-private let supportedWrapperSdkSourceIds: [SourceID] = [.flutter, .openFeatureSwift]
 
 fileprivate extension String {
     func isNotEmpty() -> Bool {

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -78,13 +78,13 @@ public struct BKTConfig {
             return self
         }
 
-        // Sets the SDK sourceID explicitly.
+        // Sets the SDK sourceId explicitly.
         // IMPORTANT: This option is intended for internal use only.
         // It should NOT be set by developers directly integrating this SDK.
         // Use this option ONLY when another SDK acts as a proxy and wraps this native SDK.
-        // In such cases, set this value to the sourceID of the proxy SDK.
+        // In such cases, set this value to the sourceId of the proxy SDK.
         // The wrapperSdkSourceId is used to identify the origin of the request.
-        // We don't public SourceID enum because only Flutter and OpenFeature Swift are supported currently.
+        // We don't expose the SourceID enum publicly because only Flutter and OpenFeature Swift are currently supported.
         public func with(wrapperSdkSourceId: Int) -> Builder {
             self.wrapperSdkSourceId = wrapperSdkSourceId
             return self

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -143,7 +143,7 @@ extension BKTConfig {
         var pollingInterval: Int64 = builder.pollingInterval ?? Constant.MINIMUM_POLLING_INTERVAL_MILLIS
         var backgroundPollingInterval: Int64 = builder.backgroundPollingInterval ?? Constant.MINIMUM_BACKGROUND_POLLING_INTERVAL_MILLIS
         var eventsFlushInterval: Int64 = builder.eventsFlushInterval ?? Constant.DEFAULT_FLUSH_INTERVAL_MILLIS
-        var eventsMaxQueueSize = builder.eventsMaxQueueSize ?? Constant.DEFAULT_MAX_QUEUE_SIZE
+        let eventsMaxQueueSize = builder.eventsMaxQueueSize ?? Constant.DEFAULT_MAX_QUEUE_SIZE
 
         guard !apiKey.isEmpty else {
             throw BKTError.illegalArgument(message: "apiKey is required")

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -68,11 +68,23 @@ public struct BKTConfig {
             return self
         }
 
+        // Sets the SDK version explicitly.
+        // IMPORTANT: This option is intended for internal use only.
+        // It should NOT be set by developers directly integrating this SDK.
+        // Use this option ONLY when another SDK acts as a proxy and wraps this native SDK.
+        // In such cases, set this value to the version of the proxy SDK.
         public func with(wrapperSdkVersion: String) -> Builder {
             self.wrapperSdkVersion = wrapperSdkVersion
             return self
         }
 
+        // Sets the SDK sourceID explicitly.
+        // IMPORTANT: This option is intended for internal use only.
+        // It should NOT be set by developers directly integrating this SDK.
+        // Use this option ONLY when another SDK acts as a proxy and wraps this native SDK.
+        // In such cases, set this value to the sourceID of the proxy SDK.
+        // The wrapperSdkSourceId is used to identify the origin of the request.
+        // We don't public SourceID enum because only Flutter and OpenFeature Swift are supported currently.
         public func with(wrapperSdkSourceId: Int) -> Builder {
             self.wrapperSdkSourceId = wrapperSdkSourceId
             return self
@@ -178,6 +190,8 @@ extension BKTConfig {
     }
 }
 
+// Only Flutter (8) and OpenFeature Swift (101) are supported currently.
+// Other source IDs will throw an error as its not from iOS
 private let supportedWrapperSdkSourceIds: [SourceID] = [.flutter, .openFeatureSwift]
 
 private func resolveSdkSourceId(wrapperSdkSourceId: Int?) throws -> SourceID {

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -195,7 +195,7 @@ private func resolveSdkSourceId(wrapperSdkSourceId: Int?) throws -> SourceID {
         return .ios // native
     }
     // There is only one supported wrapperSdkSourceId (flutter) for now
-    if let sourceId = SourceID(rawValue: wrapperSdkSourceId), sourceId == .flutter {
+    if let sourceId = SourceID(rawValue: wrapperSdkSourceId), supportedWrapperSdkSourceIds.contains(sourceId) {
         return .flutter
     }
     throw BKTError.illegalArgument(message: "Unsupported wrapperSdkSourceId: \(wrapperSdkSourceId)")
@@ -210,6 +210,8 @@ private func resolveSdkVersion(resolveSdkSourceId: SourceID, wrapperSdkVersion: 
     }
     return Version.current
 }
+
+private let supportedWrapperSdkSourceIds: [SourceID] = [.flutter, .openFeatureSwift]
 
 fileprivate extension String {
     func isNotEmpty() -> Bool {

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -196,7 +196,7 @@ private func resolveSdkSourceId(wrapperSdkSourceId: Int?) throws -> SourceID {
     }
     // There is only one supported wrapperSdkSourceId (flutter) for now
     if let sourceId = SourceID(rawValue: wrapperSdkSourceId), supportedWrapperSdkSourceIds.contains(sourceId) {
-        return .flutter
+        return sourceId
     }
     throw BKTError.illegalArgument(message: "Unsupported wrapperSdkSourceId: \(wrapperSdkSourceId)")
 }

--- a/Bucketeer/Sources/Public/BKTConfig.swift
+++ b/Bucketeer/Sources/Public/BKTConfig.swift
@@ -12,8 +12,6 @@ public struct BKTConfig {
     let sdkVersion: String
     let appVersion: String
     let logger: BKTLogger?
-    let wrapperSdkVersion: String?
-    let wrapperSdkSourceId: Int?
 
     public class Builder {
         private(set) var apiKey: String?
@@ -176,13 +174,13 @@ extension BKTConfig {
         self.eventsMaxQueueSize = eventsMaxQueueSize
         self.pollingInterval = pollingInterval
         self.backgroundPollingInterval = backgroundPollingInterval
-        self.wrapperSdkVersion = builder.wrapperSdkVersion
-        self.wrapperSdkSourceId = builder.wrapperSdkSourceId
+
         let resolvedSdkSourceId = try resolveSdkSourceId(wrapperSdkSourceId: builder.wrapperSdkSourceId)
         let resolvedSdkVersion = try resolveSdkVersion(
             resolveSdkSourceId: resolvedSdkSourceId,
             wrapperSdkVersion: builder.wrapperSdkVersion
         )
+
         self.sourceId = resolvedSdkSourceId
         self.sdkVersion = resolvedSdkVersion
         self.appVersion = appVersion

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -37,8 +37,8 @@ class ApiClientTests: XCTestCase {
                 let jsonString = String(data: data, encoding: .utf8) ?? ""
                 let expected = """
 {
-  "sdkVersion" : "\(Version.current)",
-  "sourceId" : 2,
+  "sdkVersion" : "12.3.5",
+  "sourceId" : 101,
   "tag" : "tag1",
   "user" : {
     "data" : {
@@ -68,7 +68,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
-            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            sdkInfo: SDKInfo(sourceId: .openFeatureSwift, sdkVersion: "12.3.5"),
             session: session,
             logger: nil
         )

--- a/BucketeerTests/ApiClientTests.swift
+++ b/BucketeerTests/ApiClientTests.swift
@@ -68,6 +68,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -115,8 +116,8 @@ class ApiClientTests: XCTestCase {
                 let jsonString = String(data: data, encoding: .utf8) ?? ""
                 let expected = """
 {
-  "sdkVersion" : "\(Version.current)",
-  "sourceId" : 2,
+  "sdkVersion" : "10.3.5",
+  "sourceId" : 101,
   "tag" : "tag1",
   "user" : {
     "data" : {
@@ -146,6 +147,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .openFeatureSwift, sdkVersion: "10.3.5"),
             session: session,
             logger: nil
         )
@@ -174,7 +176,7 @@ class ApiClientTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.expectedFulfillmentCount = 2
 
-        let events: [Event] = [.mockGoal1, .mockEvaluation1]
+        let events: [Event] = [.mockGoalSourceFlutter, .mockEvaluationSourceFlutter]
         let errors: [String: RegisterEventsResponse.ErrorResponse] = [
             Event.mockEvaluation1.id: .init(retriable: true, message: "error")
         ]
@@ -202,8 +204,8 @@ class ApiClientTests: XCTestCase {
           "device_type" : "mobile",
           "os_version" : "16.0"
         },
-        "sdkVersion" : "0.0.1",
-        "sourceId" : 2,
+        "sdkVersion" : "13.3.1",
+        "sourceId" : 8,
         "tag" : "tag1",
         "timestamp" : 1,
         "user" : {
@@ -233,8 +235,8 @@ class ApiClientTests: XCTestCase {
           "ruleId" : "rule1",
           "type" : "RULE"
         },
-        "sdkVersion" : "0.0.1",
-        "sourceId" : 2,
+        "sdkVersion" : "13.3.1",
+        "sourceId" : 8,
         "tag" : "tag1",
         "timestamp" : 1,
         "user" : {
@@ -250,8 +252,8 @@ class ApiClientTests: XCTestCase {
       "type" : 3
     }
   ],
-  "sdkVersion" : "\(Version.current)",
-  "sourceId" : 2
+  "sdkVersion" : "13.3.1",
+  "sourceId" : 8
 }
 """
                 XCTAssertEqual(jsonString, expected)
@@ -269,6 +271,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .flutter, sdkVersion: "13.3.1"),
             session: session,
             logger: nil
         )
@@ -380,6 +383,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -457,6 +461,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -518,6 +523,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             defaultRequestTimeoutMills: 200,
             session: session,
             logger: nil
@@ -580,6 +586,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             defaultRequestTimeoutMills: 200,
             session: session,
             logger: nil
@@ -643,6 +650,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             defaultRequestTimeoutMills: 200,
             session: session,
             logger: nil
@@ -703,6 +711,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -763,6 +772,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -823,6 +833,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -889,6 +900,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -932,6 +944,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -1013,6 +1026,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: MockLogger()
         )
@@ -1125,6 +1139,7 @@ class ApiClientTests: XCTestCase {
             apiEndpoint: apiEndpointURL,
             apiKey: apiKey,
             featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
             session: session,
             logger: nil
         )
@@ -1218,6 +1233,7 @@ class ApiClientTests: XCTestCase {
                 apiEndpoint: apiEndpointURL,
                 apiKey: apiKey,
                 featureTag: "tag1",
+                sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
                 defaultRequestTimeoutMills: 200,
                 session: session,
                 logger: nil
@@ -1291,6 +1307,7 @@ class ApiClientTests: XCTestCase {
                 apiEndpoint: apiEndpointURL,
                 apiKey: apiKey,
                 featureTag: "tag1",
+                sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
                 defaultRequestTimeoutMills: 200,
                 session: session,
                 logger: nil

--- a/BucketeerTests/BKTConfigTests.swift
+++ b/BucketeerTests/BKTConfigTests.swift
@@ -261,6 +261,7 @@ final class BKTConfigTests: XCTestCase {
     }
 
     func testOnlyAllowSupportedWrapperSDKs() {
+        // Only Flutter (8) and OpenFeature Swift (101) are supported currently
         let unsupportedIds = [0, 1, 2, 3, 4, 5, 6, 9, 10, 100, 102, 103, 104, 999, -1]
         for id in unsupportedIds {
             let builder = BKTConfig.Builder()

--- a/BucketeerTests/BKTConfigTests.swift
+++ b/BucketeerTests/BKTConfigTests.swift
@@ -3,8 +3,6 @@ import XCTest
 
 final class BKTConfigTests: XCTestCase {
 
-    let flutterSourceId = 8
-
     func testCreateConfig() {
         let logger = MockLogger()
         // Not set interval values
@@ -242,26 +240,28 @@ final class BKTConfigTests: XCTestCase {
         }
     }
 
-    func testResovleSourceIdFromWrapperSDKSourceId() {
-        let builder = BKTConfig.Builder()
-            .with(apiKey: "api_key_value")
-            .with(apiEndpoint: "https://test.bucketeer.io")
-            .with(featureTag: "featureTag")
-            .with(appVersion: "1.0.0")
-            .with(wrapperSdkSourceId: flutterSourceId)
-            .with(wrapperSdkVersion: "1.2.3")
-
-        do {
-            let config = try builder.build()
-            XCTAssertEqual(config.sourceId, SourceID.flutter)
-            XCTAssertEqual(config.sdkVersion, "1.2.3")
-        } catch {
-            XCTFail("Unexpected error: \(error)")
+    func testResolveSourceIdFromWrapperSDKSourceId() {
+        let supportedIds = [SourceID.flutter.rawValue, SourceID.openFeatureSwift.rawValue]
+        for id in supportedIds {
+            let builder = BKTConfig.Builder()
+                .with(apiKey: "api_key_value")
+                .with(apiEndpoint: "https://test.bucketeer.io")
+                .with(featureTag: "featureTag")
+                .with(appVersion: "1.0.0")
+                .with(wrapperSdkSourceId: id)
+                .with(wrapperSdkVersion: "2.3.0")
+            do {
+                let config = try builder.build()
+                XCTAssertEqual(config.sourceId, SourceID(rawValue: id))
+                XCTAssertEqual(config.sdkVersion, "2.3.0")
+            } catch {
+                XCTFail("Unexpected error: \(error)")
+            }
         }
     }
 
     func testOnlyAllowSupportedWrapperSDKs() {
-        let unsupportedIds = [0, 1, 3, 999, -1]
+        let unsupportedIds = [0, 1, 2, 3, 4, 5, 6, 9, 10, 100, 102, 103, 104, 999, -1]
         for id in unsupportedIds {
             let builder = BKTConfig.Builder()
                 .with(apiKey: "api_key_value")
@@ -288,7 +288,7 @@ final class BKTConfigTests: XCTestCase {
             .with(apiEndpoint: "https://test.bucketeer.io")
             .with(featureTag: "featureTag")
             .with(appVersion: "1.0.0")
-            .with(wrapperSdkSourceId: flutterSourceId)
+            .with(wrapperSdkSourceId: SourceID.flutter.rawValue)
 
         do {
             _ = try builder.build()

--- a/BucketeerTests/BKTConfigTests.swift
+++ b/BucketeerTests/BKTConfigTests.swift
@@ -3,6 +3,8 @@ import XCTest
 
 final class BKTConfigTests: XCTestCase {
 
+    let flutterSourceId = 8
+
     func testCreateConfig() {
         let logger = MockLogger()
         // Not set interval values
@@ -246,7 +248,7 @@ final class BKTConfigTests: XCTestCase {
             .with(apiEndpoint: "https://test.bucketeer.io")
             .with(featureTag: "featureTag")
             .with(appVersion: "1.0.0")
-            .with(wrapperSdkSourceId: 8)
+            .with(wrapperSdkSourceId: flutterSourceId)
             .with(wrapperSdkVersion: "1.2.3")
 
         do {
@@ -286,7 +288,7 @@ final class BKTConfigTests: XCTestCase {
             .with(apiEndpoint: "https://test.bucketeer.io")
             .with(featureTag: "featureTag")
             .with(appVersion: "1.0.0")
-            .with(wrapperSdkSourceId: 8)
+            .with(wrapperSdkSourceId: flutterSourceId)
 
         do {
             _ = try builder.build()

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -266,7 +266,15 @@ class BKTErrorTests: XCTestCase {
         for errorCase in BKTError.allCases {
             let apiId : ApiId = .getEvaluations
             let labels = ["key":"value"]
-            let eventData = errorCase.toMetricsEventData(apiId: .getEvaluations, labels: ["key":"value"], currentTimeSeconds: 1000, sdkVersion: "1.0.0", metadata: ["key_metadata":"data"])
+            let sourceId = SourceID.ios
+            let sdkVersion = "1.0.0"
+            let eventData = errorCase.toMetricsEventData(
+                apiId: .getEvaluations,
+                labels: ["key":"value"],
+                currentTimeSeconds: 1000,
+                sdkInfo: SDKInfo(sourceId: sourceId, sdkVersion: sdkVersion),
+                metadata: ["key_metadata":"data"]
+            )
             let metricsEventData: MetricsEventData
             let metricsEventType: MetricsEventType
             switch errorCase {

--- a/BucketeerTests/BKTErrorTests.swift
+++ b/BucketeerTests/BKTErrorTests.swift
@@ -266,13 +266,12 @@ class BKTErrorTests: XCTestCase {
         for errorCase in BKTError.allCases {
             let apiId : ApiId = .getEvaluations
             let labels = ["key":"value"]
-            let sourceId = SourceID.ios
-            let sdkVersion = "1.0.0"
+            let sdkInfo = SDKInfo.testSample()
             let eventData = errorCase.toMetricsEventData(
                 apiId: .getEvaluations,
                 labels: ["key":"value"],
                 currentTimeSeconds: 1000,
-                sdkInfo: SDKInfo(sourceId: sourceId, sdkVersion: sdkVersion),
+                sdkInfo: sdkInfo,
                 metadata: ["key_metadata":"data"]
             )
             let metricsEventData: MetricsEventData
@@ -342,8 +341,8 @@ class BKTErrorTests: XCTestCase {
                 timestamp: 1000,
                 event: metricsEventData,
                 type: metricsEventType,
-                sourceId: .ios,
-                sdk_version: "1.0.0",
+                sourceId: sdkInfo.sourceId,
+                sdk_version: sdkInfo.sdkVersion,
                 metadata: ["key_metadata":"data"]
             ))
             XCTAssertEqual(eventData, expectedEventData)

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -38,10 +38,10 @@ final class E2EEventTests: XCTestCase {
                 XCTFail("could not access client.component")
                 return
             }
-            
+
             try await Task.sleep(nanoseconds: 300_000_000)
             client.assert(expectedEventCount: 3)
-            
+
             let events = try component.dataModule.eventSQLDao.getEvents()
 
             XCTAssertTrue(events.contains { event in
@@ -53,7 +53,7 @@ final class E2EEventTests: XCTestCase {
                 }
                 return false
             })
-            
+
             try await client.flush()
             client.assert(expectedEventCount: 0)
         } catch {

--- a/BucketeerTests/E2E/E2EEventWrapperSourceIdTests.swift
+++ b/BucketeerTests/E2E/E2EEventWrapperSourceIdTests.swift
@@ -5,8 +5,6 @@ import XCTest
 @available(iOS 13, *)
 final class E2EEventWrapperSourceIdTests: XCTestCase {
 
-    private var config: BKTConfig!
-
     override func setUp() async throws {
         try await super.setUp()
         UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
@@ -130,11 +128,6 @@ final class E2EEventWrapperSourceIdTests: XCTestCase {
             XCTAssertEqual(client.intVariation(featureId: FEATURE_ID_INT, defaultValue: 100), 100)
             XCTAssertEqual(client.doubleVariation(featureId: FEATURE_ID_DOUBLE, defaultValue: 3.0), 3.0)
             XCTAssertEqual(client.boolVariation(featureId: FEATURE_ID_BOOLEAN, defaultValue: false), false)
-
-            guard let component = client.component as? ComponentImpl else {
-                XCTFail("could not access client.component")
-                return
-            }
 
             // Wait for events to be processed
             try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds

--- a/BucketeerTests/E2E/E2EEventWrapperSourceIdTests.swift
+++ b/BucketeerTests/E2E/E2EEventWrapperSourceIdTests.swift
@@ -1,0 +1,146 @@
+import Foundation
+import XCTest
+@testable import Bucketeer
+
+@available(iOS 13, *)
+final class E2EEventWrapperSourceIdTests: XCTestCase {
+
+    private var config: BKTConfig!
+
+    override func setUp() async throws {
+        try await super.setUp()
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+
+        let config = try BKTConfig.e2e(wrapperSdkSourceId: SourceID.flutter, wrapperSdkVersion: "1.2.10")
+        let user = try BKTUser.Builder().with(id: USER_ID).build()
+        try await BKTClient.initialize(
+            config: config,
+            user: user
+        )
+    }
+
+    override func tearDown() async throws {
+        try await super.tearDown()
+
+        try await BKTClient.shared.flush()
+        try BKTClient.destroy()
+        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        try FileManager.default.removeItem(at: .database)
+    }
+
+    func testTrack() async throws {
+        do {
+            let client = try BKTClient.shared
+            client.assert(expectedEventCount: 2)
+            client.track(goalId: GOAL_ID, value: GOAL_VALUE)
+            try await Task.sleep(nanoseconds: 300_000_000)
+            client.assert(expectedEventCount: 3)
+            try await client.flush()
+            client.assert(expectedEventCount: 0)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    // refs: https://github.com/bucketeer-io/javascript-client-sdk/blob/main/e2e/events.spec.ts#L112
+    func testEvaluationEvents() async throws {
+        do {
+            let client = try BKTClient.shared
+            XCTAssertEqual(client.stringVariation(featureId: FEATURE_ID_STRING, defaultValue: ""), "value-1")
+            XCTAssertEqual(client.intVariation(featureId: FEATURE_ID_INT, defaultValue: 0), 10)
+            XCTAssertEqual(client.intVariation(featureId: FEATURE_ID_DOUBLE, defaultValue: 0), 2)
+            XCTAssertEqual(client.doubleVariation(featureId: FEATURE_ID_DOUBLE, defaultValue: 0.0), 2.1)
+            XCTAssertEqual(client.boolVariation(featureId: FEATURE_ID_BOOLEAN, defaultValue: false), true)
+
+            guard let component = client.component as? ComponentImpl else {
+                XCTFail("could not access client.component")
+                return
+            }
+
+            // getVariationValue() is logging events using another dispatch queue, we need to wait a few secs
+            try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+            let events = try component.dataModule.eventSQLDao.getEvents()
+            // It includes the Latency and ResponseSize metrics
+            XCTAssertTrue(events.count >= 5)
+            XCTAssertTrue(events.contains { event in
+                if case .evaluation = event.type,
+                    case .evaluation(let data) = event.event,
+                    case .default = data.reason.type,
+                    case .flutter = data.sourceId,
+                    data.sdkVersion == "1.2.10" && data.sdkVersion != Version.current {
+                    return true
+                }
+                return false
+            })
+
+            try await client.flush()
+
+            XCTAssertEqual(try component.dataModule.eventSQLDao.getEvents().count, 0)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+
+    func testDefaultEvaluationEvents() async throws {
+        do {
+            let client = try BKTClient.shared
+            guard let component = client.component as? ComponentImpl else {
+                XCTFail("could not access client.component")
+                return
+            }
+            try await withCheckedThrowingContinuation({ continuation in
+                client.execute {
+                    do {
+                        try component.dataModule.evaluationStorage.deleteAllAndInsert(evaluationId: "evaluationId", evaluations: [], evaluatedAt: "0")
+                        continuation.resume(returning: ())
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            })
+
+            // Wait for the event to be added
+            try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+
+            // After clearing evaluations, we expect 2 metrics events (Latency and ResponseSize)
+            client.assert(expectedEventCount: 2)
+
+            // Wait for the clear operation to complete
+            try await Task.sleep(nanoseconds: 300_000_000) // 300 milliseconds
+
+            // Make variation calls to generate default evaluation events
+            XCTAssertEqual(client.stringVariation(featureId: FEATURE_ID_STRING, defaultValue: "value-default"), "value-default")
+            XCTAssertEqual(client.intVariation(featureId: FEATURE_ID_INT, defaultValue: 100), 100)
+            XCTAssertEqual(client.doubleVariation(featureId: FEATURE_ID_DOUBLE, defaultValue: 3.0), 3.0)
+            XCTAssertEqual(client.boolVariation(featureId: FEATURE_ID_BOOLEAN, defaultValue: false), false)
+
+            guard let component = client.component as? ComponentImpl else {
+                XCTFail("could not access client.component")
+                return
+            }
+
+            // Wait for events to be processed
+            try await Task.sleep(nanoseconds: 2_000_000_000) // 2 seconds
+
+            let events = try component.dataModule.eventSQLDao.getEvents()
+            // It includes the Latency and ResponseSize metrics
+            XCTAssertTrue(events.count >= 5, "Expected at least 5 events but got \(events.count)")
+            XCTAssertTrue(events.contains { event in
+                if case .evaluation = event.type,
+                    case .evaluation(let data) = event.event,
+                    case .client = data.reason.type,
+                    case .flutter = data.sourceId,
+                    data.sdkVersion == "1.2.10" && data.sdkVersion != Version.current {
+                    return true
+                }
+                return false
+            })
+
+            try await client.flush()
+
+            XCTAssertEqual(try component.dataModule.eventSQLDao.getEvents().count, 0)
+        } catch {
+            XCTFail(error.localizedDescription)
+        }
+    }
+}

--- a/BucketeerTests/E2E/E2EMetricsEventTests.swift
+++ b/BucketeerTests/E2E/E2EMetricsEventTests.swift
@@ -70,7 +70,6 @@ final class E2EMetricsEventTests: XCTestCase {
         }
 
         let events2 : [Event] = try component.dataModule.eventSQLDao.getEvents()
-        // It includes the Latency and ResponseSize metrics
         XCTAssertEqual(events2.count, 0)
     }
 

--- a/BucketeerTests/E2E/E2ETestHelpers.swift
+++ b/BucketeerTests/E2E/E2ETestHelpers.swift
@@ -16,16 +16,26 @@ let GOAL_VALUE = 1.0
 
 @available(iOS 13, *)
 extension BKTConfig {
-    static func e2e(featureTag: String = FEATURE_TAG) throws -> BKTConfig {
+    static func e2e(
+        featureTag: String = FEATURE_TAG,
+        wrapperSdkSourceId: SourceID? = nil,
+        wrapperSdkVersion: String? = nil
+    ) throws -> BKTConfig {
         let apiKey = ProcessInfo.processInfo.environment["E2E_API_KEY"]!
         let apiEndpoint = ProcessInfo.processInfo.environment["E2E_API_ENDPOINT"]!
 
-        let builder = BKTConfig.Builder()
+        var builder = BKTConfig.Builder()
             .with(apiKey: apiKey)
             .with(apiEndpoint: apiEndpoint)
             .with(featureTag: featureTag)
             .with(appVersion: "1.2.3")
             .with(logger: E2ELogger())
+        if let wrapperSdkSourceId = wrapperSdkSourceId, let sdkVersion = wrapperSdkVersion {
+            // Set only when using wrapper SDK
+            builder = builder
+                .with(wrapperSdkSourceId: wrapperSdkSourceId.rawValue)
+                .with(wrapperSdkVersion: sdkVersion)
+        }
 
         return try builder.build()
     }

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -6,12 +6,13 @@ final class EventInteractorTests: XCTestCase {
     private func eventInteractor(api: ApiClient = MockApiClient(),
                                  dao: EventSQLDao = MockEventSQLDao(),
                                  config: BKTConfig = BKTConfig.mock(),
-                                 idGenerator: IdGenerator = MockIdGenerator(identifier: "id")
+                                 idGenerator: IdGenerator = MockIdGenerator(identifier: "id"),
+                                 sdkInfo: SDKInfo = .init(sourceId: .ios, sdkVersion: "0.0.2")
     ) -> EventInteractor {
         let clock = MockClock(timestamp: 1)
         let logger = MockLogger()
         return EventInteractorImpl(
-            sdkInfo: .init(sourceId: .ios, sdkVersion: "0.0.2"),
+            sdkInfo: sdkInfo,
             appVersion: "1.2.3",
             device: MockDevice(),
             eventsMaxBatchQueueCount: 3,
@@ -24,10 +25,19 @@ final class EventInteractorTests: XCTestCase {
         )
     }
 
+    private func sdkInfoTestSample() -> SDKInfo {
+        // random sourceId and sdkVersion for testing
+        let sourceIds: [SourceID] = [.unknown, .android, .ios, .flutter, .react, .openFeatureKotlin, .openFeatureSwift]
+        let randomSourceId = sourceIds.randomElement() ?? .ios
+        let randomSdkVersion = "test-\(Int.random(in: 1...100))"
+        return SDKInfo(sourceId: randomSourceId, sdkVersion: randomSdkVersion)
+    }
+
     func testTrackEvaluationEvent() throws {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 1)
             let expected = Event(
@@ -41,8 +51,8 @@ final class EventInteractorTests: XCTestCase {
                     user: .mock1,
                     reason: Evaluation.mock1.reason,
                     tag: "featureTag1",
-                    sourceId: .ios,
-                    sdkVersion: "0.0.2",
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: [
                         "app_version": "1.2.3",
                         "os_version": "16.0",
@@ -68,7 +78,8 @@ final class EventInteractorTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
 
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 1)
             let expected = Event(
@@ -80,8 +91,8 @@ final class EventInteractorTests: XCTestCase {
                     user: .mock1,
                     reason: .init(type: .client),
                     tag: "featureTag1",
-                    sourceId: .ios,
-                    sdkVersion: "0.0.2",
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: [
                         "app_version": "1.2.3",
                         "os_version": "16.0",
@@ -107,7 +118,8 @@ final class EventInteractorTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
 
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 1)
             let expected = Event(
@@ -119,8 +131,8 @@ final class EventInteractorTests: XCTestCase {
                     value: 1,
                     user: .mock1,
                     tag: "featureTag1",
-                    sourceId: .ios,
-                    sdkVersion: "0.0.2",
+                    sourceId: sdkInfo.sourceId,
+                    sdkVersion: sdkInfo.sdkVersion,
                     metadata: [
                         "app_version": "1.2.3",
                         "os_version": "16.0",
@@ -147,7 +159,8 @@ final class EventInteractorTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
 
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 2)
             let expected: [Event] = [
@@ -161,8 +174,8 @@ final class EventInteractorTests: XCTestCase {
                             latencySecond: .init(10)
                         )),
                         type: .responseLatency,
-                        sourceId: .ios,
-                        sdk_version: "0.0.2",
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: [
                             "app_version": "1.2.3",
                             "os_version": "16.0",
@@ -182,8 +195,8 @@ final class EventInteractorTests: XCTestCase {
                             sizeByte: 100
                         )),
                         type: .responseSize,
-                        sourceId: .ios,
-                        sdk_version: "0.0.2",
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: [
                             "app_version": "1.2.3",
                             "os_version": "16.0",
@@ -214,7 +227,8 @@ final class EventInteractorTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
 
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 1)
             let expected: [Event] = [
@@ -224,8 +238,8 @@ final class EventInteractorTests: XCTestCase {
                         timestamp: 1,
                         event: .timeoutError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1", "timeout": "3.0"])),
                         type: .timeoutError,
-                        sourceId: .ios,
-                        sdk_version: "0.0.2",
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: [
                             "app_version": "1.2.3",
                             "os_version": "16.0",
@@ -251,7 +265,8 @@ final class EventInteractorTests: XCTestCase {
         let expectation = XCTestExpectation()
         expectation.assertForOverFulfill = true
 
-        let interactor = self.eventInteractor()
+        let sdkInfo = self.sdkInfoTestSample()
+        let interactor = self.eventInteractor(sdkInfo: sdkInfo)
         let listener = MockEventUpdateListener { events in
             XCTAssertEqual(events.count, 1)
             let expected: [Event] = [
@@ -261,8 +276,8 @@ final class EventInteractorTests: XCTestCase {
                         timestamp: 1,
                         event: .badRequestError(.init(apiId: .getEvaluations, labels: ["tag": "featureTag1"])),
                         type: .badRequestError,
-                        sourceId: .ios,
-                        sdk_version: "0.0.2",
+                        sourceId: sdkInfo.sourceId,
+                        sdk_version: sdkInfo.sdkVersion,
                         metadata: [
                             "app_version": "1.2.3",
                             "os_version": "16.0",

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -26,11 +26,7 @@ final class EventInteractorTests: XCTestCase {
     }
 
     private func sdkInfoTestSample() -> SDKInfo {
-        // random sourceId and sdkVersion for testing
-        let sourceIds: [SourceID] = [.unknown, .android, .ios, .flutter, .react, .openFeatureKotlin, .openFeatureSwift]
-        let randomSourceId = sourceIds.randomElement() ?? .ios
-        let randomSdkVersion = "test-\(Int.random(in: 1...100))"
-        return SDKInfo(sourceId: randomSourceId, sdkVersion: randomSdkVersion)
+        return SDKInfo.testSample()
     }
 
     func testTrackEvaluationEvent() throws {

--- a/BucketeerTests/EventInteractorTests.swift
+++ b/BucketeerTests/EventInteractorTests.swift
@@ -11,7 +11,7 @@ final class EventInteractorTests: XCTestCase {
         let clock = MockClock(timestamp: 1)
         let logger = MockLogger()
         return EventInteractorImpl(
-            sdkVersion: "0.0.2",
+            sdkInfo: .init(sourceId: .ios, sdkVersion: "0.0.2"),
             appVersion: "1.2.3",
             device: MockDevice(),
             eventsMaxBatchQueueCount: 3,

--- a/BucketeerTests/Mock/MockBKTConfig.swift
+++ b/BucketeerTests/Mock/MockBKTConfig.swift
@@ -23,9 +23,7 @@ extension BKTConfig {
             sourceId: .ios,
             sdkVersion: "0.0.2",
             appVersion: "1.2.3",
-            logger: MockLogger(),
-            wrapperSdkVersion: nil,
-            wrapperSdkSourceId: nil
+            logger: MockLogger()
         )
     }
 }

--- a/BucketeerTests/Mock/MockBKTConfig.swift
+++ b/BucketeerTests/Mock/MockBKTConfig.swift
@@ -25,7 +25,7 @@ extension BKTConfig {
             appVersion: "1.2.3",
             logger: MockLogger(),
             wrapperSdkVersion: nil,
-            wrapperSdkSourceId: nil,
+            wrapperSdkSourceId: nil
         )
     }
 }

--- a/BucketeerTests/Mock/MockBKTConfig.swift
+++ b/BucketeerTests/Mock/MockBKTConfig.swift
@@ -20,9 +20,12 @@ extension BKTConfig {
             eventsMaxQueueSize: eventsMaxQueueSize,
             pollingInterval: pollingInterval,
             backgroundPollingInterval: backgroundPollingInterval,
+            sourceId: .ios,
             sdkVersion: "0.0.2",
             appVersion: "1.2.3",
-            logger: MockLogger()
+            logger: MockLogger(),
+            wrapperSdkVersion: nil,
+            wrapperSdkSourceId: nil,
         )
     }
 }

--- a/BucketeerTests/Mock/MockEvents.swift
+++ b/BucketeerTests/Mock/MockEvents.swift
@@ -23,6 +23,27 @@ extension Event {
         type: .goal
     )
 
+    static let mockGoalSourceFlutter = Event(
+        id: "goal_event1",
+        event: .goal(.init(
+            timestamp: 1,
+            goalId: "goal1",
+            userId: User.mock1.id,
+            value: 1,
+            user: .mock1,
+            tag: "tag1",
+            sourceId: .flutter,
+            sdkVersion: "13.3.1",
+            metadata: [
+                "app_version": "1.2.3",
+                "os_version": "16.0",
+                "device_model": "iPhone14,7",
+                "device_type": "mobile"
+            ]
+        )),
+        type: .goal
+    )
+
     static let mockGoal2 = Event(
         id: "goal_event2",
         event: .goal(.init(
@@ -57,6 +78,29 @@ extension Event {
             tag: "tag1",
             sourceId: .ios,
             sdkVersion: "0.0.1",
+            metadata: [
+                "app_version": "1.2.3",
+                "os_version": "16.0",
+                "device_model": "iPhone14,7",
+                "device_type": "mobile"
+            ]
+        )),
+        type: .evaluation
+    )
+
+    static let mockEvaluationSourceFlutter = Event(
+        id: "evaluation_event1",
+        event: .evaluation(.init(
+            timestamp: 1,
+            featureId: "feature1",
+            featureVersion: 1,
+            userId: User.mock1.id,
+            variationId: "variation1",
+            user: .mock1,
+            reason: .init(type: .rule, ruleId: "rule1"),
+            tag: "tag1",
+            sourceId: .flutter,
+            sdkVersion: "13.3.1",
             metadata: [
                 "app_version": "1.2.3",
                 "os_version": "16.0",

--- a/BucketeerTests/Mock/MockSDKInfo.swift
+++ b/BucketeerTests/Mock/MockSDKInfo.swift
@@ -1,0 +1,12 @@
+import Foundation
+@testable import Bucketeer
+
+extension SDKInfo {
+    static func testSample() -> SDKInfo {
+        // random sourceId and sdkVersion for testing
+        let sourceIds: [SourceID] = [.unknown, .android, .ios, .flutter, .react, .openFeatureKotlin, .openFeatureSwift]
+        let randomSourceId = sourceIds.randomElement() ?? .ios
+        let randomSdkVersion = "test-\(Int.random(in: 1...100))"
+        return SDKInfo(sourceId: randomSourceId, sdkVersion: randomSdkVersion)
+    }
+}

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,19 @@ BUILD_FOR_TESTING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	build-for-testing
 TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \
-	-skip-testing:BucketeerTests/E2E* \
+	-skip-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
+	-skip-testing:BucketeerTests/E2EEvaluationTests \
+	-skip-testing:BucketeerTests/E2EEventTests \
+	-skip-testing:BucketeerTests/E2EMetricsEventTests \
+	-skip-testing:BucketeerTests/E2EEventWrapperSourceIdTests \
 	test-without-building
 E2E_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \
-	-only-testing:BucketeerTests/E2E* \
+	-only-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
+	-only-testing:BucketeerTests/E2EEvaluationTests \
+	-only-testing:BucketeerTests/E2EEventTests \
+	-only-testing:BucketeerTests/E2EMetricsEventTests \
+	-only-testing:BucketeerTests/E2EEventWrapperSourceIdTests \
 	test-without-building E2E_API_ENDPOINT=$(E2E_API_ENDPOINT) E2E_API_KEY=$(E2E_API_KEY)
 ALL_TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,11 @@ BUILD_FOR_TESTING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	build-for-testing
 TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \
-	-skip-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
-	-skip-testing:BucketeerTests/E2EEvaluationTests \
-	-skip-testing:BucketeerTests/E2EEventTests \
-	-skip-testing:BucketeerTests/E2EMetricsEventTests \
+	-skip-testing:BucketeerTests/E2E* \
 	test-without-building
 E2E_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \
-	-only-testing:BucketeerTests/E2EBKTClientForceUpdateTests \
-	-only-testing:BucketeerTests/E2EEvaluationTests \
-	-only-testing:BucketeerTests/E2EEventTests \
-	-only-testing:BucketeerTests/E2EMetricsEventTests \
+	-only-testing:BucketeerTests/E2E* \
 	test-without-building E2E_API_ENDPOINT=$(E2E_API_ENDPOINT) E2E_API_KEY=$(E2E_API_KEY)
 ALL_TEST_WITHOUT_BUILDING=$(XCODEBUILD) $(BUILD_SETTINGS) $(OPTIONS) $(DESTINATION) \
 	-configuration $(CONFIGURATION) \


### PR DESCRIPTION
This pull request refactors how SDK version and source ID information are handled and propagated throughout the SDK, enabling better support for wrapper SDKs (such as Flutter or OpenFeature Swift). The changes introduce a new `SDKInfo` struct to encapsulate this data, update constructors and method signatures to use `SDKInfo`, and add configuration options for wrapper SDKs to set their own version and source ID. This improves flexibility and ensures accurate tracking of the SDK origin in events and API requests.

Key changes include:

**SDK Metadata Handling:**

- Introduced a new `SDKInfo` struct to encapsulate both `sourceId` and `sdkVersion`, replacing direct usage of these fields in event and API logic. 
- Updated the `SourceID` enum with additional cases to represent new wrapper SDKs (Flutter, React, OpenFeature, etc.), allowing accurate identification of the SDK source.

**Configuration and Builder Enhancements:**

- Added `sourceId` to `BKTConfig` and exposed internal builder methods (`with(wrapperSdkVersion:)` and `with(wrapperSdkSourceId:)`) to allow wrapper SDKs to set their own version and source ID. These are clearly documented as internal-use-only and not intended for direct use by end developers. 

- Refactored `BKTConfig` initialization to ensure all configuration passes through the builder for consistent validation and normalization. (`Bucketeer/Sources/Public/BKTConfig.swift` [Bucketeer/Sources/Public/BKTConfig.swiftL94-R167](diffhunk://#diff-a01b127e0bdeebe208c5ce7cac0dfd53041a03921bc362c81bdb3954f333d81eL94-R167))

These changes collectively improve the SDK's ability to support and track wrapper SDKs, and ensure that all events and API requests accurately reflect the true origin and version of the SDK in use.