### PR TITLE
feat: thread-safe user attribute update tracking and safe reading/updating of evaluations

### DIFF
--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -123,28 +123,6 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
         try evaluationStorage.refreshCache()
     }
 
-    /*
-     Note: Logical race condition on `userAttributesUpdated`
-
-     Problem:
-     - `userAttributesUpdated` is a boolean that only indicates "there exists at least one pending attribute change".
-     - If the flag is already `true` when a fetch starts, and attributes are updated again while the request is in-flight, the fetch cannot distinguish the new update from the old one.
-     - The fetch may clear the flag on completion (because it saw `true` at start), causing any updates that happened during the request to be lost.
-
-     Example (double-update):
-     1) flag = true
-     2) fetch starts and reads true
-     3) attributes updated again (flag remains true)
-     4) fetch completes and clears flag
-     5) the second update is never sent
-
-     Conclusion:
-     A single boolean cannot represent "which" update was sent; clearing it after a fetch can discard concurrent updates.
-     
-     Solution: Use a version number to track the state of user attributes updates.
-     Each update increments the version, and clearing only happens if the version matches
-     ensuring concurrent updates are not lost.
-    */
     func setUserAttributesUpdated() {
         // https://github.com/bucketeer-io/android-client-sdk/issues/69
         // userAttributesUpdated: when the user attributes change via the customAttributes interface,

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -47,8 +47,9 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
 
         let logger = self.logger
         let evaluatedAt = evaluationStorage.evaluatedAt
-        let userAttributesUpdated = evaluationStorage.userAttributesUpdated
-        let userAttributesUpdatedVersion = evaluationStorage.userAttributesUpdatedVersion
+        let userAttributesState = evaluationStorage.userAttributesState
+        let userAttributesUpdated = userAttributesState.isUpdated
+        let userAttributesUpdatedVersion = userAttributesState.version
         let currentEvaluationsId = evaluationStorage.currentEvaluationsId
         let featureTag = evaluationStorage.featureTag
 

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationInteractor.swift
@@ -49,7 +49,6 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
         let evaluatedAt = evaluationStorage.evaluatedAt
         let userAttributesState = evaluationStorage.userAttributesState
         let userAttributesUpdated = userAttributesState.isUpdated
-        let userAttributesUpdatedVersion = userAttributesState.version
         let currentEvaluationsId = evaluationStorage.currentEvaluationsId
         let featureTag = evaluationStorage.featureTag
 
@@ -65,10 +64,8 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
                 let newEvaluationsId = response.userEvaluationsId
                 if currentEvaluationsId == newEvaluationsId {
                     logger?.debug(message: "Nothing to sync")
-                    // Only clear if we sent the update AND the version hasn't changed
-                    if userAttributesUpdated {
-                        self?.evaluationStorage.clearUserAttributesUpdated(version: userAttributesUpdatedVersion)
-                    }
+                    // Clear logic is now encapsulated in `evaluationStorage` via the state snapshot
+                    self?.evaluationStorage.clearUserAttributesUpdated(state: userAttributesState)
                     completion?(result)
                     return
                 }
@@ -102,10 +99,8 @@ final class EvaluationInteractorImpl: EvaluationInteractor {
                     return
                 }
 
-                // Only clear if we sent the update AND the version hasn't changed
-                if userAttributesUpdated {
-                    self?.evaluationStorage.clearUserAttributesUpdated(version: userAttributesUpdatedVersion)
-                }
+                // Clear logic is now encapsulated in `evaluationStorage` via the state snapshot
+                self?.evaluationStorage.clearUserAttributesUpdated(state: userAttributesState)
 
                 if shouldNotifyListener {
                     // Update listeners should be called on the main thread

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
@@ -12,16 +12,16 @@ class InMemoryCache<T: Any>: KeyValueCache {
     private let queue = DispatchQueue(label: "io.bucketeer.InMemoryCache", attributes: .concurrent)
 
     func set(key: String, value: T) {
-        // .barrier ensures this write waits for current reads to finish,
-        // and blocks new reads until the write is done.
+        // .barrier ensures exclusive access: it waits for pending reads to finish and blocks new ones during the write.
+        // .sync ensures the update completes before returning, guaranteeing that subsequent reads immediately receive the new value.
         queue.sync(flags: .barrier) {
             self.dict[key] = value
         }
     }
 
     func get(key: String) -> T? {
-        // .sync returns the value immediately.
-        // Because the queue is concurrent, this does NOT block other readers.
+        // .sync waits for this read block to run, then returns its value.
+        // Reads can run in parallel on the concurrent queue, but this call will wait if a barrier write is in progress or queued ahead of it.
         queue.sync {
             return dict[key]
         }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
@@ -14,7 +14,7 @@ class InMemoryCache<T: Any>: KeyValueCache {
     func set(key: String, value: T) {
         // .barrier ensures this write waits for current reads to finish,
         // and blocks new reads until the write is done.
-        queue.async(flags: .barrier) {
+        queue.sync(flags: .barrier) {
             self.dict[key] = value
         }
     }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -21,9 +21,10 @@ protocol EvaluationStorage {
     // expected set evaluatedAt from `deleteAllAndInsert` or `update` only
     var evaluatedAt: String { get }
     var userAttributesUpdated: Bool { get }
+    var userAttributesUpdatedVersion: Int { get }
 
     func clearCurrentEvaluationsId()
     func setFeatureTag(value: String)
     func setUserAttributesUpdated()
-    func clearUserAttributesUpdated()
+    func clearUserAttributesUpdated(version: Int)
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -51,11 +51,10 @@ protocol EvaluationStorage {
 /// whole across app restarts.
 ///
 /// The ephemeral nature of the version counter is intentional. We employ an Optimistic Locking pattern where the integer value does not need to persist across app restarts:
-/// On Restart: The persisted isUpdated flag is authoritative. If true, we trigger an immediate sync, regardless of the version.
-/// During Runtime: The version acts as a transaction ID to safely handle race conditions where user attributes change while a background fetch is in progress.
-/// Correctness: The update flag is only cleared via a Compare-and-Swap check (currentVersion == capturedVersion).
-/// If the user modifies attributes during a fetch, the version increments, the check fails, and the flag remains true to schedule a subsequent sync.
-
+/// - On restart: The persisted `isUpdated` flag is authoritative. If `true`, an immediate sync is triggered, regardless of the version.
+/// - During runtime: The `version` acts as a transaction ID to safely handle race conditions where user attributes change while a background fetch is in progress.
+/// - Correctness: The update flag is only cleared via a compare-and-swap check (`currentVersion == capturedVersion`).
+/// If the user modifies attributes during a fetch, the `version` increments, the check fails, and the flag remains `true` to schedule a subsequent sync.
 struct UserAttributesState {
     let version: Int
     let isUpdated: Bool

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -49,6 +49,13 @@ protocol EvaluationStorage {
 /// Use this struct as an in-memory snapshot to coordinate whether evaluations must be refreshed
 /// due to user attribute changes during a single session. It is not intended to be persisted as a
 /// whole across app restarts.
+///
+/// The ephemeral nature of the version counter is intentional. We employ an Optimistic Locking pattern where the integer value does not need to persist across app restarts:
+/// On Restart: The persisted isUpdated flag is authoritative. If true, we trigger an immediate sync, regardless of the version.
+/// During Runtime: The version acts as a transaction ID to safely handle race conditions where user attributes change while a background fetch is in progress.
+/// Correctness: The update flag is only cleared via a Compare-and-Swap check (currentVersion == capturedVersion).
+/// If the user modifies attributes during a fetch, the version increments, the check fails, and the flag remains true to schedule a subsequent sync.
+
 struct UserAttributesState {
     let version: Int
     let isUpdated: Bool

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -27,7 +27,14 @@ protocol EvaluationStorage {
     func clearCurrentEvaluationsId()
     func setFeatureTag(value: String)
     func setUserAttributesUpdated()
-    func clearUserAttributesUpdated(version: Int)
+
+    /// Atomically clear the user-attributes-updated flag if the stored version equals `state.version`.
+    /// - Parameter state: Snapshot obtained from `userAttributesState` before a network request.
+    /// - Returns: `true` if the flag was cleared (stored flag was `true` and versions matched); `false` otherwise.
+    /// - Thread-safety: Implementations MUST perform the compare\-and\-swap under the storage's internal lock.
+    /// - Note: `version` is an in\-memory, session-only counter; implementations may persist only the
+    /// boolean flag (e.g., in `UserDefaults`), but the `version` must be treated as transient.
+    @discardableResult func clearUserAttributesUpdated(state: UserAttributesState) -> Bool
 }
 
 /// Snapshot representing the current user-attributes update state for the current app session.

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -21,6 +21,8 @@ protocol EvaluationStorage {
     // expected set evaluatedAt from `deleteAllAndInsert` or `update` only
     var evaluatedAt: String { get }
     var userAttributesUpdated: Bool { get }
+
+    // increments when `setUserAttributesUpdated` is called
     var userAttributesUpdatedVersion: Int { get }
 
     func clearCurrentEvaluationsId()

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -22,11 +22,25 @@ protocol EvaluationStorage {
     var evaluatedAt: String { get }
     var userAttributesUpdated: Bool { get }
 
-    // increments when `setUserAttributesUpdated` is called
-    var userAttributesUpdatedVersion: Int { get }
+    // Current version and flag set when `setUserAttributesUpdated()` is called
+    var userAttributesState: UserAttributesState { get }
 
     func clearCurrentEvaluationsId()
     func setFeatureTag(value: String)
     func setUserAttributesUpdated()
     func clearUserAttributesUpdated(version: Int)
+}
+
+/// Snapshot representing the current user-attributes update state.
+///
+/// - `version`: Monotonically increasing counter. Incremented each time `setUserAttributesUpdated()`
+///   is called to indicate a new update event.
+/// - `isUpdated`: `true` if user attributes have been modified since the last evaluation (i.e., a
+///   new update event exists); `false` otherwise.
+///
+/// Use this struct to persist or return the minimal state needed to determine whether evaluations
+/// must be refreshed due to user attribute changes.
+struct UserAttributesState {
+    let version: Int
+    let isUpdated: Bool
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -31,15 +31,18 @@ protocol EvaluationStorage {
     func clearUserAttributesUpdated(version: Int)
 }
 
-/// Snapshot representing the current user-attributes update state.
+/// Snapshot representing the current user-attributes update state for the current app session.
 ///
 /// - `version`: Monotonically increasing counter. Incremented each time `setUserAttributesUpdated()`
-///   is called to indicate a new update event.
+///   is called to indicate a new update event. This value is kept in memory only and is not
+///   persisted across app restarts.
 /// - `isUpdated`: `true` if user attributes have been modified since the last evaluation (i.e., a
-///   new update event exists); `false` otherwise.
+///   new update event exists); `false` otherwise. Implementations may persist this flag (for
+///   example, in `UserDefaults`) to survive restarts.
 ///
-/// Use this struct to persist or return the minimal state needed to determine whether evaluations
-/// must be refreshed due to user attribute changes.
+/// Use this struct as an in-memory snapshot to coordinate whether evaluations must be refreshed
+/// due to user attribute changes during a single session. It is not intended to be persisted as a
+/// whole across app restarts.
 struct UserAttributesState {
     let version: Int
     let isUpdated: Bool

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -20,7 +20,6 @@ protocol EvaluationStorage {
     var featureTag: String { get }
     // expected set evaluatedAt from `deleteAllAndInsert` or `update` only
     var evaluatedAt: String { get }
-    var userAttributesUpdated: Bool { get }
 
     // Current version and flag set when `setUserAttributesUpdated()` is called
     var userAttributesState: UserAttributesState { get }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorage.swift
@@ -31,8 +31,8 @@ protocol EvaluationStorage {
     /// Atomically clear the user-attributes-updated flag if the stored version equals `state.version`.
     /// - Parameter state: Snapshot obtained from `userAttributesState` before a network request.
     /// - Returns: `true` if the flag was cleared (stored flag was `true` and versions matched); `false` otherwise.
-    /// - Thread-safety: Implementations MUST perform the compare\-and\-swap under the storage's internal lock.
-    /// - Note: `version` is an in\-memory, session-only counter; implementations may persist only the
+    /// - Thread-safety: Implementations MUST perform the compare-and-swap under the storage's internal lock.
+    /// - Note: `version` is an in-memory, session-only counter; implementations may persist only the
     /// boolean flag (e.g., in `UserDefaults`), but the `version` must be treated as transient.
     @discardableResult func clearUserAttributesUpdated(state: UserAttributesState) -> Bool
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -17,9 +17,7 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     private let userId: String
-    // Expected SQL Dao
     private let evaluationSQLDao: EvaluationSQLDao
-    // Expected in-memory cache Dao
     private let evaluationMemCacheDao: EvaluationMemCacheDao
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
 

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -17,47 +17,11 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     private let userId: String
+    // Expected SQL Dao
     private let evaluationSQLDao: EvaluationSQLDao
+    // Expected in-memory cache Dao
     private let evaluationMemCacheDao: EvaluationMemCacheDao
-    // UserDefaults is thread-safe by design, no additional locking needed
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
-
-    // IMPORTANT: Why lock at Storage layer instead of InMemoryCache?
-    //
-    // Threading Model:
-    // - WRITES (deleteAllAndInsert/update): Always run on SDK's serial dispatchQueue
-    //   (via BKTClient.execute {} in line 238-248 of BKTClient.swift)
-    // - READS (getBy): Called directly from main thread in BKTClient.getBKTEvaluationDetails()
-    //   (line 17 of BKTClient.swift) -> NO execute {} wrapper!
-    //
-    // Lock Protects TWO Critical Aspects:
-    //
-    // 1. Thread-safety for concurrent read-write access to evaluationMemCacheDao (Dictionary)
-    //    - Main thread reads via getBy() -> evaluationMemCacheDao.get()
-    //    - SDK queue writes via update()/deleteAllAndInsert() -> evaluationMemCacheDao.set()
-    //    - Swift Dictionary is NOT thread-safe for concurrent read-write operations!
-    //    - Race condition: Main thread reading while SDK queue is writing would cause crashes or data corruption
-    //
-    // 2. Atomicity of compound operations (SQL + UserDefaults + Cache)
-    //    Example: forceUpdate() must be atomic:
-    //      a. SQL: delete all + insert new (in transaction)
-    //      b. UserDefaults: update evaluatedAt + currentEvaluationsId
-    //      c. Cache: update evaluationMemCacheDao
-    //    Without lock at Storage layer, getBy() could read stale cache while SQL is already updated,
-    //    resulting in inconsistent state between storage layers!
-    //
-    // Why NOT Lock in InMemoryCache?
-    // - Even if InMemoryCache has its own lock for dictionary access, we STILL need lock here
-    //   to ensure atomicity of compound operations across SQL + UserDefaults + Cache
-    // - Would result in 2 locks (InMemoryCache + Storage) with no benefit, just added complexity
-    // - Lock in InMemoryCache only protects dictionary access, NOT the compound operation atomicity
-    // - Current design: Single lock at Storage layer protects BOTH thread-safety AND atomicity
-    //
-    // Example Race Condition Without Storage-Level Lock:
-    //   Thread 1 (SDK Queue): update() reads SQL -> modifies data -> writes SQL + Cache
-    //   Thread 2 (Main):      getBy() reads Cache (gets inconsistent data between read and write)
-    //   Result: User sees evaluation that doesn't match what's in SQL!
-    private let lock = NSLock()
 
     init(
         userId: String,
@@ -73,30 +37,10 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     func get() throws -> [Evaluation] {
-        return lock.withLock {
-            evaluationMemCacheDao.get(key: userId) ?? []
-        }
+        evaluationMemCacheDao.get(key: userId) ?? []
     }
 
     func deleteAllAndInsert(
-        evaluationId: String,
-        evaluations: [Evaluation],
-        evaluatedAt: String) throws {
-        try lock.withLock {
-            try forceUpdate(
-                evaluationId: evaluationId,
-                evaluations: evaluations,
-                evaluatedAt: evaluatedAt
-            )
-        }
-    }
-
-    // forceUpdate performs an atomic compound operation:
-    // 1. SQL: Delete all existing evaluations and insert new ones (in transaction)
-    // 2. UserDefaults: Update evaluatedAt and currentEvaluationsId
-    // 3. Cache: Update evaluationMemCacheDao
-    // The caller (deleteAllAndInsert/update) must hold the lock to ensure atomicity across all three storage layers
-    private func forceUpdate(
         evaluationId: String,
         evaluations: [Evaluation],
         evaluatedAt: String) throws {
@@ -107,64 +51,50 @@ final class EvaluationStorageImpl: EvaluationStorage {
 
         evaluationUserDefaultsDao.setEvaluatedAt(value: evaluatedAt)
         evaluationUserDefaultsDao.setCurrentEvaluationsId(value: evaluationId)
-        // Update in-memory cache to reflect the new state
+        // Update cache directly
         evaluationMemCacheDao.set(key: userId, value: evaluations)
     }
 
-    // update performs incremental update of evaluations:
-    // 1. Fetch current evaluations from SQL
-    // 2. Upsert new evaluations (update existing or add new)
-    // 3. Remove archived feature flags
-    // 4. Atomically update all storage layers (SQL + UserDefaults + Cache)
-    // Returns true if any changes were made (new evaluations or archived features)
     func update(
         evaluationId: String ,
         evaluations: [Evaluation],
         archivedFeatureIds: [String],
         evaluatedAt: String) throws -> Bool {
-        try lock.withLock {
-            // 1. Build a map of current evaluations by featureId
-            var currentEvaluationsByFeatureId = try evaluationSQLDao.get(userId: userId)
-                .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
-                    var output = input
-                    output[evaluation.featureId] = evaluation
-                    return output
-                }
-            // 2. Upsert new evaluations (overwrite existing or add new)
-            for evaluation in evaluations {
-                currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
+        // 1. Get current data in db
+        var currentEvaluationsByFeatureId = try evaluationSQLDao.get(userId: userId)
+            .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
+                var output = input
+                output[evaluation.featureId] = evaluation
+                return output
             }
-            // 3. Filter out archived features to get active evaluations
-            let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
-                !archivedFeatureIds.contains(evaluation.featureId)
-            }.map { item in
-                item
-            }
-            // 4. Atomically save to all storage layers
-            try forceUpdate(
-                evaluationId: evaluationId ,
-                evaluations: currentEvaluations,
-                evaluatedAt: evaluatedAt)
-            return evaluations.count > 0 || archivedFeatureIds.count > 0
+        // 2. Update evaluation with new data
+        for evaluation in evaluations {
+            currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
         }
+        // 3. Filter active
+        let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
+            !archivedFeatureIds.contains(evaluation.featureId)
+        }.map { item in
+            item
+        }
+        // 4. Save to database
+        try deleteAllAndInsert(
+            evaluationId: evaluationId ,
+            evaluations: currentEvaluations,
+            evaluatedAt: evaluatedAt)
+        return evaluations.count > 0 || archivedFeatureIds.count > 0
     }
 
-    // getBy returns data from the in-memory cache for fast access.
-    // This is called on every feature flag evaluation (from main thread via BKTClient.getBKTEvaluationDetails),
-    // so using the cache avoids expensive SQL queries on the critical path.
+    // getBy will return the data from the cache to speed up the response time
     func getBy(featureId: String) -> Evaluation? {
-        return lock.withLock {
-            return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
-                evaluation.featureId == featureId
-            } ?? nil
-        }
+        return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
+            evaluation.featureId == featureId
+        } ?? nil
     }
 
     func refreshCache() throws {
-        try lock.withLock {
-            let evaluationsInDb = try evaluationSQLDao.get(userId: userId)
-            evaluationMemCacheDao.set(key: userId, value: evaluationsInDb)
-        }
+        let evaluationsInDb = try evaluationSQLDao.get(userId: userId)
+        evaluationMemCacheDao.set(key: userId, value: evaluationsInDb)
     }
 
     func clearCurrentEvaluationsId() {

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -17,11 +17,46 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     private let userId: String
-    // Expected SQL Dao
     private let evaluationSQLDao: EvaluationSQLDao
-    // Expected in-memory cache Dao
     private let evaluationMemCacheDao: EvaluationMemCacheDao
+    // UserDefaults is thread-safe by design, no additional locking needed
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
+    
+    // IMPORTANT: Why lock at Storage layer instead of InMemoryCache?
+    //
+    // Threading Model:
+    // - WRITES (deleteAllAndInsert/update): Always run on SDK's serial dispatchQueue
+    //   (via BKTClient.execute {} in line 238-248 of BKTClient.swift)
+    // - READS (getBy): Called directly from main thread in BKTClient.getBKTEvaluationDetails()
+    //   (line 17 of BKTClient.swift) -> NO execute {} wrapper!
+    //
+    // Lock Protects TWO Critical Aspects:
+    //
+    // 1. Thread-safety for concurrent read-write access to evaluationMemCacheDao (Dictionary)
+    //    - Main thread reads via getBy() -> evaluationMemCacheDao.get()
+    //    - SDK queue writes via update()/deleteAllAndInsert() -> evaluationMemCacheDao.set()
+    //    - Swift Dictionary is NOT thread-safe for concurrent read-write operations!
+    //    - Race condition: Main thread reading while SDK queue is writing would cause crashes or data corruption
+    //
+    // 2. Atomicity of compound operations (SQL + UserDefaults + Cache)
+    //    Example: forceUpdate() must be atomic:
+    //      a. SQL: delete all + insert new (in transaction)
+    //      b. UserDefaults: update evaluatedAt + currentEvaluationsId
+    //      c. Cache: update evaluationMemCacheDao
+    //    Without lock at Storage layer, getBy() could read stale cache while SQL is already updated,
+    //    resulting in inconsistent state between storage layers!
+    //
+    // Why NOT Lock in InMemoryCache?
+    // - Even if InMemoryCache has its own lock for dictionary access, we STILL need lock here
+    //   to ensure atomicity of compound operations across SQL + UserDefaults + Cache
+    // - Would result in 2 locks (InMemoryCache + Storage) with no benefit, just added complexity
+    // - Lock in InMemoryCache only protects dictionary access, NOT the compound operation atomicity
+    // - Current design: Single lock at Storage layer protects BOTH thread-safety AND atomicity
+    //
+    // Example Race Condition Without Storage-Level Lock:
+    //   Thread 1 (SDK Queue): update() reads SQL -> modifies data -> writes SQL + Cache
+    //   Thread 2 (Main):      getBy() reads Cache (gets inconsistent data between read and write)
+    //   Result: User sees evaluation that doesn't match what's in SQL!
     private let lock = NSLock()
 
     init(
@@ -56,6 +91,11 @@ final class EvaluationStorageImpl: EvaluationStorage {
         }
     }
 
+    // forceUpdate performs an atomic compound operation:
+    // 1. SQL: Delete all existing evaluations and insert new ones (in transaction)
+    // 2. UserDefaults: Update evaluatedAt and currentEvaluationsId
+    // 3. Cache: Update evaluationMemCacheDao
+    // The caller (deleteAllAndInsert/update) must hold the lock to ensure atomicity across all three storage layers
     private func forceUpdate(
         evaluationId: String,
         evaluations: [Evaluation],
@@ -67,34 +107,40 @@ final class EvaluationStorageImpl: EvaluationStorage {
 
         evaluationUserDefaultsDao.setEvaluatedAt(value: evaluatedAt)
         evaluationUserDefaultsDao.setCurrentEvaluationsId(value: evaluationId)
-        // Update cache directly
+        // Update in-memory cache to reflect the new state
         evaluationMemCacheDao.set(key: userId, value: evaluations)
     }
 
+    // update performs incremental update of evaluations:
+    // 1. Fetch current evaluations from SQL
+    // 2. Upsert new evaluations (update existing or add new)
+    // 3. Remove archived feature flags
+    // 4. Atomically update all storage layers (SQL + UserDefaults + Cache)
+    // Returns true if any changes were made (new evaluations or archived features)
     func update(
         evaluationId: String ,
         evaluations: [Evaluation],
         archivedFeatureIds: [String],
         evaluatedAt: String) throws -> Bool {
         try lock.withLock {
-            // 1. Get current data in db
+            // 1. Build a map of current evaluations by featureId
             var currentEvaluationsByFeatureId = try evaluationSQLDao.get(userId: userId)
                 .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
                     var output = input
                     output[evaluation.featureId] = evaluation
                     return output
                 }
-            // 2. Update evaluation with new data
+            // 2. Upsert new evaluations (overwrite existing or add new)
             for evaluation in evaluations {
                 currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
             }
-            // 3. Filter active
+            // 3. Filter out archived features to get active evaluations
             let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
                 !archivedFeatureIds.contains(evaluation.featureId)
             }.map { item in
                 item
             }
-            // 4. Save to database
+            // 4. Atomically save to all storage layers
             try forceUpdate(
                 evaluationId: evaluationId ,
                 evaluations: currentEvaluations,
@@ -103,7 +149,9 @@ final class EvaluationStorageImpl: EvaluationStorage {
         }
     }
 
-    // getBy will return the data from the cache to speed up the response time
+    // getBy returns data from the in-memory cache for fast access.
+    // This is called on every feature flag evaluation (from main thread via BKTClient.getBKTEvaluationDetails),
+    // so using the cache avoids expensive SQL queries on the critical path.
     func getBy(featureId: String) -> Evaluation? {
         return lock.withLock {
             return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
@@ -120,26 +168,18 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     func clearCurrentEvaluationsId() {
-        lock.withLock {
-            evaluationUserDefaultsDao.setCurrentEvaluationsId(value: "")
-        }
+        evaluationUserDefaultsDao.setCurrentEvaluationsId(value: "")
     }
 
     func setFeatureTag(value: String) {
-        lock.withLock {
-            evaluationUserDefaultsDao.setFeatureTag(value: value)
-        }
+        evaluationUserDefaultsDao.setFeatureTag(value: value)
     }
 
     func setUserAttributesUpdated() {
-        lock.withLock {
-            evaluationUserDefaultsDao.setUserAttributesUpdated(value: true)
-        }
+        evaluationUserDefaultsDao.setUserAttributesUpdated(value: true)
     }
 
     func clearUserAttributesUpdated() {
-        lock.withLock {
-            evaluationUserDefaultsDao.setUserAttributesUpdated(value: false)
-        }
+        evaluationUserDefaultsDao.setUserAttributesUpdated(value: false)
     }
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -21,7 +21,7 @@ final class EvaluationStorageImpl: EvaluationStorage {
     private let evaluationMemCacheDao: EvaluationMemCacheDao
     // UserDefaults is thread-safe by design, no additional locking needed
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
-    
+
     // IMPORTANT: Why lock at Storage layer instead of InMemoryCache?
     //
     // Threading Model:

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -22,6 +22,7 @@ final class EvaluationStorageImpl: EvaluationStorage {
     // Expected in-memory cache Dao
     private let evaluationMemCacheDao: EvaluationMemCacheDao
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
+    private let lock = NSLock()
 
     init(
         userId: String,
@@ -37,79 +38,108 @@ final class EvaluationStorageImpl: EvaluationStorage {
     }
 
     func get() throws -> [Evaluation] {
-        evaluationMemCacheDao.get(key: userId) ?? []
+        return lock.withLock {
+            evaluationMemCacheDao.get(key: userId) ?? []
+        }
     }
 
     func deleteAllAndInsert(
         evaluationId: String,
         evaluations: [Evaluation],
         evaluatedAt: String) throws {
-        try evaluationSQLDao.startTransaction {
-            try evaluationSQLDao.deleteAll(userId: userId)
-            try evaluationSQLDao.put(evaluations: evaluations)
+            try lock.withLock {
+                try forceUpdate(
+                    evaluationId: evaluationId,
+                    evaluations: evaluations,
+                    evaluatedAt: evaluatedAt
+                )
+            }
         }
 
-        evaluationUserDefaultsDao.setEvaluatedAt(value: evaluatedAt)
-        evaluationUserDefaultsDao.setCurrentEvaluationsId(value: evaluationId)
-        // Update cache directly
-        evaluationMemCacheDao.set(key: userId, value: evaluations)
-    }
+    private func forceUpdate(
+        evaluationId: String,
+        evaluations: [Evaluation],
+        evaluatedAt: String) throws {
+            try evaluationSQLDao.startTransaction {
+                try evaluationSQLDao.deleteAll(userId: userId)
+                try evaluationSQLDao.put(evaluations: evaluations)
+            }
+
+            evaluationUserDefaultsDao.setEvaluatedAt(value: evaluatedAt)
+            evaluationUserDefaultsDao.setCurrentEvaluationsId(value: evaluationId)
+            // Update cache directly
+            evaluationMemCacheDao.set(key: userId, value: evaluations)
+        }
 
     func update(
         evaluationId: String ,
         evaluations: [Evaluation],
         archivedFeatureIds: [String],
         evaluatedAt: String) throws -> Bool {
-        // 1. Get current data in db
-        var currentEvaluationsByFeatureId = try evaluationSQLDao.get(userId: userId)
-            .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
-                var output = input
-                output[evaluation.featureId] = evaluation
-                return output
+            try lock.withLock {
+                // 1. Get current data in db
+                var currentEvaluationsByFeatureId = try evaluationSQLDao.get(userId: userId)
+                    .reduce([String:Evaluation]()) { (input, evaluation) -> [String:Evaluation] in
+                        var output = input
+                        output[evaluation.featureId] = evaluation
+                        return output
+                    }
+                // 2. Update evaluation with new data
+                for evaluation in evaluations {
+                    currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
+                }
+                // 3. Filter active
+                let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
+                    !archivedFeatureIds.contains(evaluation.featureId)
+                }.map { item in
+                    item
+                }
+                // 4. Save to database
+                try forceUpdate(
+                    evaluationId: evaluationId ,
+                    evaluations: currentEvaluations,
+                    evaluatedAt: evaluatedAt)
+                return evaluations.count > 0 || archivedFeatureIds.count > 0
             }
-        // 2. Update evaluation with new data
-        for evaluation in evaluations {
-            currentEvaluationsByFeatureId[evaluation.featureId] = evaluation
         }
-        // 3. Filter active
-        let currentEvaluations = currentEvaluationsByFeatureId.values.filter { evaluation in
-            !archivedFeatureIds.contains(evaluation.featureId)
-        }.map { item in
-            item
-        }
-        // 4. Save to database
-        try deleteAllAndInsert(
-            evaluationId: evaluationId ,
-            evaluations: currentEvaluations,
-            evaluatedAt: evaluatedAt)
-        return evaluations.count > 0 || archivedFeatureIds.count > 0
-    }
 
     // getBy will return the data from the cache to speed up the response time
     func getBy(featureId: String) -> Evaluation? {
-        return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
-            evaluation.featureId == featureId
-        } ?? nil
+        return lock.withLock {
+            return evaluationMemCacheDao.get(key: userId)?.first { evaluation in
+                evaluation.featureId == featureId
+            } ?? nil
+        }
     }
 
     func refreshCache() throws {
-        let evaluationsInDb = try evaluationSQLDao.get(userId: userId)
-        evaluationMemCacheDao.set(key: userId, value: evaluationsInDb)
+        try lock.withLock {
+            let evaluationsInDb = try evaluationSQLDao.get(userId: userId)
+            evaluationMemCacheDao.set(key: userId, value: evaluationsInDb)
+        }
     }
 
     func clearCurrentEvaluationsId() {
-        evaluationUserDefaultsDao.setCurrentEvaluationsId(value: "")
+        lock.withLock {
+            evaluationUserDefaultsDao.setCurrentEvaluationsId(value: "")
+        }
     }
 
     func setFeatureTag(value: String) {
-        evaluationUserDefaultsDao.setFeatureTag(value: value)
+        lock.withLock {
+            evaluationUserDefaultsDao.setFeatureTag(value: value)
+        }
     }
 
     func setUserAttributesUpdated() {
-        evaluationUserDefaultsDao.setUserAttributesUpdated(value: true)
+        lock.withLock {
+            evaluationUserDefaultsDao.setUserAttributesUpdated(value: true)
+        }
     }
 
     func clearUserAttributesUpdated() {
-        evaluationUserDefaultsDao.setUserAttributesUpdated(value: false)
+        lock.withLock {
+            evaluationUserDefaultsDao.setUserAttributesUpdated(value: false)
+        }
     }
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -48,6 +48,8 @@ final class EvaluationStorageImpl: EvaluationStorage {
         evaluationMemCacheDao.get(key: userId) ?? []
     }
 
+    /// Deletes all evaluations and inserts new evaluations in storage.
+    /// - Note: Caller must ensure this is called from the SDK queue. Not thread-safe
     func deleteAllAndInsert(
         evaluationId: String,
         evaluations: [Evaluation],
@@ -63,6 +65,8 @@ final class EvaluationStorageImpl: EvaluationStorage {
         evaluationMemCacheDao.set(key: userId, value: evaluations)
     }
 
+    /// Updates evaluations in storage.
+    /// - Note: Caller must ensure this is called from the SDK queue. Not thread-safe for concurrent writes.
     func update(
         evaluationId: String ,
         evaluations: [Evaluation],

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -30,8 +30,10 @@ final class EvaluationStorageImpl: EvaluationStorage {
     private var userAttributesUpdated: Bool {
         return evaluationUserDefaultsDao.userAttributesUpdated
     }
-    private var userAttributesUpdatedVersion: Int = 0
     private let setUserAttributesUpdatedLock = NSLock()
+    /// Version counter used as an in-memory transaction id for attribute updates.
+    /// Protected by `setUserAttributesUpdatedLock`.
+    private var userAttributesUpdatedVersion: Int = 0
 
     init(
         userId: String,

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -26,10 +26,6 @@ final class EvaluationStorageImpl: EvaluationStorage {
     private let evaluationSQLDao: EvaluationSQLDao
     private let evaluationMemCacheDao: EvaluationMemCacheDao
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
-
-    private var userAttributesUpdated: Bool {
-        return evaluationUserDefaultsDao.userAttributesUpdated
-    }
     private let setUserAttributesUpdatedLock = NSLock()
     /// Version counter used as an in-memory transaction id for attribute updates.
     /// Protected by `setUserAttributesUpdatedLock`.

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -95,7 +95,9 @@ final class EvaluationStorageImpl: EvaluationStorage {
     // getBy will return the data from the cache to speed up the response time
     func getBy(featureId: String) -> Evaluation? {
         // evaluationMemCacheDao is thread-safe (uses internal concurrent queue).
-        // We rely on it without adding extra locks because this storage layer is also accessed serially via the SDK queue.
+        // We rely on it without adding extra locks even though this storage layer can be accessed from multiple threads:
+        // writes and most operations are serialized on the SDK queue, but reads (like getBy) may be invoked from the
+        // main/UI thread concurrently with background SDK operations.
         //
         // We access the memory cache directly without waiting for pending database writes.
         // If we enforced strict consistency (locking during Disk I/O with SQL), this method would block the calling thread (often the Main Thread), causing UI freezes.

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -12,10 +12,6 @@ final class EvaluationStorageImpl: EvaluationStorage {
         return evaluationUserDefaultsDao.evaluatedAt
     }
 
-    var userAttributesUpdated: Bool {
-        return evaluationUserDefaultsDao.userAttributesUpdated
-    }
-
     var userAttributesState: UserAttributesState {
         // read atomically 2 values
         return setUserAttributesUpdatedLock.withLock {
@@ -31,6 +27,9 @@ final class EvaluationStorageImpl: EvaluationStorage {
     private let evaluationMemCacheDao: EvaluationMemCacheDao
     private let evaluationUserDefaultsDao: EvaluationUserDefaultsDao
 
+    private var userAttributesUpdated: Bool {
+        return evaluationUserDefaultsDao.userAttributesUpdated
+    }
     private var userAttributesUpdatedVersion: Int = 0
     private let setUserAttributesUpdatedLock = NSLock()
 
@@ -136,7 +135,7 @@ final class EvaluationStorageImpl: EvaluationStorage {
     func clearUserAttributesUpdated(version: Int) {
         setUserAttributesUpdatedLock.withLock {
             // Only clear if the version matches what we captured at the start of the request.
-            // If _userAttributesUpdatedVersion > version, it means a new update happened
+            // If userAttributesUpdatedVersion > version, it means a new update happened
             // while the request was in-flight, so we MUST NOT clear the flag.
             if userAttributesUpdatedVersion == version {
                 evaluationUserDefaultsDao.setUserAttributesUpdated(value: false)

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
@@ -1,10 +1,7 @@
 import Foundation
 
 class EvaluationUserDefaultDaoImpl: EvaluationUserDefaultsDao {
-    private static let userEvaluationsIdKey = "bucketeer_user_evaluations_id"
-    private static let featureTagKey = "bucketeer_feature_tag"
-    private static let evaluatedAtKey = "bucketeer_evaluated_at"
-    private static let userAttributesUpdatedKey = "bucketeer_user_attributes_updated"
+
     private let defs: Defaults
 
     init(defaults: Defaults) {
@@ -13,34 +10,34 @@ class EvaluationUserDefaultDaoImpl: EvaluationUserDefaultsDao {
 
     var userAttributesUpdated: Bool {
         get {
-            return defs.bool(forKey: Self.userAttributesUpdatedKey)
+            return defs.bool(forKey: EvaluationUserDefaultsKey.userAttributesUpdated.rawValue)
         }
         set {
-            defs.set(newValue, forKey: Self.userAttributesUpdatedKey)
+            defs.set(newValue, forKey: EvaluationUserDefaultsKey.userAttributesUpdated.rawValue)
         }
     }
     var currentEvaluationsId: String {
         get {
-            return defs.string(forKey: Self.userEvaluationsIdKey) ?? ""
+            return defs.string(forKey: EvaluationUserDefaultsKey.userEvaluationsId.rawValue) ?? ""
         }
         set {
-            defs.set(newValue, forKey: Self.userEvaluationsIdKey)
+            defs.set(newValue, forKey: EvaluationUserDefaultsKey.userEvaluationsId.rawValue)
         }
     }
     var featureTag: String {
         get {
-            return defs.string(forKey: Self.featureTagKey) ?? ""
+            return defs.string(forKey: EvaluationUserDefaultsKey.featureTag.rawValue) ?? ""
         }
         set {
-            defs.set(newValue, forKey: Self.featureTagKey)
+            defs.set(newValue, forKey: EvaluationUserDefaultsKey.featureTag.rawValue)
         }
     }
     var evaluatedAt: String {
         get {
-            return defs.string(forKey: Self.evaluatedAtKey) ?? "0"
+            return defs.string(forKey: EvaluationUserDefaultsKey.evaluatedAt.rawValue) ?? "0"
         }
         set {
-            defs.set(newValue, forKey: Self.evaluatedAtKey)
+            defs.set(newValue, forKey: EvaluationUserDefaultsKey.evaluatedAt.rawValue)
         }
     }
 
@@ -58,13 +55,5 @@ class EvaluationUserDefaultDaoImpl: EvaluationUserDefaultsDao {
 
     func setUserAttributesUpdated(value: Bool) {
         userAttributesUpdated = value
-    }
-
-    // Delete all related data for testing purposes
-    func deleteAll() {
-        defs.removeObject(forKey: Self.userEvaluationsIdKey)
-        defs.removeObject(forKey: Self.featureTagKey)
-        defs.removeObject(forKey: Self.evaluatedAtKey)
-        defs.removeObject(forKey: Self.userAttributesUpdatedKey)
     }
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultDaoImpl.swift
@@ -59,4 +59,12 @@ class EvaluationUserDefaultDaoImpl: EvaluationUserDefaultsDao {
     func setUserAttributesUpdated(value: Bool) {
         userAttributesUpdated = value
     }
+
+    // Delete all related data for testing purposes
+    func deleteAll() {
+        defs.removeObject(forKey: Self.userEvaluationsIdKey)
+        defs.removeObject(forKey: Self.featureTagKey)
+        defs.removeObject(forKey: Self.evaluatedAtKey)
+        defs.removeObject(forKey: Self.userAttributesUpdatedKey)
+    }
 }

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultsDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationUserDefaultsDao.swift
@@ -11,3 +11,10 @@ protocol EvaluationUserDefaultsDao {
     func setEvaluatedAt(value: String)
     func setUserAttributesUpdated(value: Bool)
 }
+
+enum EvaluationUserDefaultsKey: String {
+    case userEvaluationsId = "bucketeer_user_evaluations_id"
+    case featureTag = "bucketeer_feature_tag"
+    case evaluatedAt = "bucketeer_evaluated_at"
+    case userAttributesUpdated = "bucketeer_user_attributes_updated"
+}

--- a/Bucketeer/Sources/Internal/Utils/Defaults.swift
+++ b/Bucketeer/Sources/Internal/Utils/Defaults.swift
@@ -4,6 +4,7 @@ protocol Defaults {
     func string(forKey defaultName: String) -> String?
     func bool(forKey defaultName: String) -> Bool
     func set(_ value: Any?, forKey defaultName: String)
+    func removeObject(forKey defaultName: String)
 }
 
 extension UserDefaults: Defaults {}

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -206,9 +206,7 @@ extension BKTClient {
         component.userHolder.updateAttributes { _ in
             attributes
         }
-        execute {
-            self.component.evaluationInteractor.setUserAttributesUpdated()
-        }
+        component.evaluationInteractor.setUserAttributesUpdated()
     }
 
     public func fetchEvaluations(timeoutMillis: Int64? = nil, completion: ((BKTError?) -> Void)? = nil) {

--- a/Bucketeer/Sources/Public/BKTClient.swift
+++ b/Bucketeer/Sources/Public/BKTClient.swift
@@ -206,7 +206,9 @@ extension BKTClient {
         component.userHolder.updateAttributes { _ in
             attributes
         }
-        component.evaluationInteractor.setUserAttributesUpdated()
+        execute {
+            self.component.evaluationInteractor.setUserAttributesUpdated()
+        }
     }
 
     public func fetchEvaluations(timeoutMillis: Int64? = nil, completion: ((BKTError?) -> Void)? = nil) {

--- a/BucketeerTests/BKTClientTests.swift
+++ b/BucketeerTests/BKTClientTests.swift
@@ -148,7 +148,7 @@ final class BKTClientTests: XCTestCase {
             // mark the next request ready
             requestCount = 2
             XCTAssertEqual(
-                dataModule.evaluationStorage.userAttributesUpdated,
+                dataModule.evaluationStorage.userAttributesState.isUpdated,
                 true, "userAttributesUpdated should be true")
             client.fetchEvaluations(timeoutMillis: nil) { error in
                 XCTAssertEqual(error, nil)

--- a/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
+++ b/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
@@ -9,7 +9,7 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
     }
 
     @MainActor
@@ -18,7 +18,7 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
+++ b/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
@@ -75,13 +75,16 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
             return
         }
 
-        let evaluationStorage = component.dataModule.evaluationStorage
-        XCTAssertNotEqual(evaluationStorage.evaluatedAt, tooOldEvaluatedAt)
-        XCTAssertNotEqual(evaluationStorage.currentEvaluationsId, randomUserEvaluationId)
+        let dispatchQueue = client.dispatchQueue
+        try dispatchQueue.sync {
+            let evaluationStorage = component.dataModule.evaluationStorage
+            XCTAssertNotEqual(evaluationStorage.evaluatedAt, tooOldEvaluatedAt)
+            XCTAssertNotEqual(evaluationStorage.currentEvaluationsId, randomUserEvaluationId)
 
-        let currentEvaluations = try evaluationStorage.get()
-        XCTAssertEqual(currentEvaluations.isEmpty, false)
-        XCTAssertFalse(currentEvaluations.contains(tobeDeletedEvaluation), "we should not have `tobeDeletedEvaluation` in the cache")
+            let currentEvaluations = try evaluationStorage.get()
+            XCTAssertEqual(currentEvaluations.isEmpty, false)
+            XCTAssertFalse(currentEvaluations.contains(tobeDeletedEvaluation), "we should not have `tobeDeletedEvaluation` in the cache")
+        }
     }
 
     // userEvaluationId is empty after feature_tag changed

--- a/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
+++ b/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
@@ -9,12 +9,7 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
-        UserDefaults.standard.removeObject(forKey: "bucketeer_feature_tag")
-        UserDefaults.standard.removeObject(forKey: "bucketeer_evaluatedAt")
-        UserDefaults.standard.removeObject(forKey: "bucketeer_userAttributesUpdated")
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
     }
 
     @MainActor
@@ -23,7 +18,7 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
+++ b/BucketeerTests/E2E/E2EBKTClientForceUpdateTests.swift
@@ -137,7 +137,7 @@ final class E2EBKTClientForceUpdateTests: XCTestCase {
             XCTAssertEqual(evaluationStorage.currentEvaluationsId, randomUserEvaluationId)
         }
 
-        // Similate feature_tag changed
+        // Simulate feature_tag changed
         try DispatchQueue.main.sync {
             try BKTClient.destroy()
         }

--- a/BucketeerTests/E2E/E2EEvaluationTests.swift
+++ b/BucketeerTests/E2E/E2EEvaluationTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import XCTest
-import Bucketeer
+@testable import Bucketeer
 
 @available(iOS 13, *)
 final class E2EEvaluationTests: XCTestCase {
@@ -10,7 +10,7 @@ final class E2EEvaluationTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
 
         let config = try BKTConfig.e2e()
         let user = try BKTUser.Builder().with(id: USER_ID).build()
@@ -26,7 +26,7 @@ final class E2EEvaluationTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EEvaluationTests.swift
+++ b/BucketeerTests/E2E/E2EEvaluationTests.swift
@@ -10,7 +10,7 @@ final class E2EEvaluationTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
 
         let config = try BKTConfig.e2e()
         let user = try BKTUser.Builder().with(id: USER_ID).build()
@@ -26,7 +26,7 @@ final class E2EEvaluationTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -9,7 +9,7 @@ final class E2EEventTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
 
         let config = try BKTConfig.e2e()
         let user = try BKTUser.Builder().with(id: USER_ID).build()
@@ -24,7 +24,7 @@ final class E2EEventTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EEventTests.swift
+++ b/BucketeerTests/E2E/E2EEventTests.swift
@@ -9,7 +9,7 @@ final class E2EEventTests: XCTestCase {
 
     override func setUp() async throws {
         try await super.setUp()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
 
         let config = try BKTConfig.e2e()
         let user = try BKTUser.Builder().with(id: USER_ID).build()
@@ -24,7 +24,7 @@ final class E2EEventTests: XCTestCase {
 
         try await BKTClient.shared.flush()
         try BKTClient.destroy()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
         try FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EMetricsEventTests.swift
+++ b/BucketeerTests/E2E/E2EMetricsEventTests.swift
@@ -10,7 +10,7 @@ final class E2EMetricsEventTests: XCTestCase {
     override func tearDown() async throws {
         try await super.tearDown()
         try BKTClient.destroy()
-        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
+        UserDefaults.removeAllEvaluationData()
         try? FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2EMetricsEventTests.swift
+++ b/BucketeerTests/E2E/E2EMetricsEventTests.swift
@@ -10,7 +10,7 @@ final class E2EMetricsEventTests: XCTestCase {
     override func tearDown() async throws {
         try await super.tearDown()
         try BKTClient.destroy()
-        UserDefaults.standard.removeObject(forKey: "bucketeer_user_evaluations_id")
+        EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard).deleteAll()
         try? FileManager.default.removeItem(at: .database)
     }
 

--- a/BucketeerTests/E2E/E2ETestHelpers.swift
+++ b/BucketeerTests/E2E/E2ETestHelpers.swift
@@ -196,3 +196,13 @@ final class MockAsyncEventUpdateListener: EvaluationUpdateListener {
         mockContinuation?.resume(returning: true)
     }
 }
+
+extension UserDefaults {
+    static func removeAllEvaluationData() {
+        let userDefs = UserDefaults.standard
+        userDefs.removeObject(forKey: EvaluationUserDefaultsKey.userEvaluationsId.rawValue)
+        userDefs.removeObject(forKey: EvaluationUserDefaultsKey.featureTag.rawValue)
+        userDefs.removeObject(forKey: EvaluationUserDefaultsKey.evaluatedAt.rawValue)
+        userDefs.removeObject(forKey: EvaluationUserDefaultsKey.userAttributesUpdated.rawValue)
+    }
+}

--- a/BucketeerTests/EvaluationInteractorTests.swift
+++ b/BucketeerTests/EvaluationInteractorTests.swift
@@ -83,7 +83,7 @@ final class EvaluationInteractorTests: XCTestCase {
             "currentEvaluationsId should be empty string"
         )
         XCTAssertEqual(
-            storage.userAttributesUpdated,
+            storage.userAttributesState.isUpdated,
             false,
             "userAttributesUpdated should be false"
         )
@@ -119,7 +119,7 @@ final class EvaluationInteractorTests: XCTestCase {
             "currentEvaluationsId should not be a empty string after fetch evaluation success"
         )
         XCTAssertEqual(
-            storage.userAttributesUpdated,
+            storage.userAttributesState.isUpdated,
             false,
             "userAttributesUpdated should be false"
         )
@@ -455,11 +455,10 @@ final class EvaluationInteractorTests: XCTestCase {
         storage.currentEvaluationsId =  baseUserEvaluationsId
         storage.featureTag =  config.featureTag
         storage.evaluatedAt = evaluationCreatedAt
-        storage.userAttributesUpdated = false
         XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
-        XCTAssertEqual(storage.userAttributesUpdated, false)
+        XCTAssertEqual(storage.userAttributesState.isUpdated, false)
         let api = MockApiClient(
             getEvaluationsHandler: { user, userEvaluationsId, _, condition, completion in
                 XCTAssertEqual(user, .mock1)
@@ -485,13 +484,13 @@ final class EvaluationInteractorTests: XCTestCase {
         XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
-        XCTAssertEqual(storage.userAttributesUpdated, false)
+        XCTAssertEqual(storage.userAttributesState.isUpdated, false)
 
         interactor.setUserAttributesUpdated()
         XCTAssertEqual(storage.currentEvaluationsId, baseUserEvaluationsId)
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, evaluationCreatedAt)
-        XCTAssertEqual(storage.userAttributesUpdated, true)
+        XCTAssertEqual(storage.userAttributesState.isUpdated, true)
 
         interactor.fetch(user: .mock1) { result in
             switch result {
@@ -508,7 +507,7 @@ final class EvaluationInteractorTests: XCTestCase {
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1.createdAt)
         // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
-        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+        XCTAssertEqual(storage.userAttributesState.isUpdated, false, "userAttributesUpdated should be `false`")
 
         wait(for: [expectation], timeout: 1)
     }
@@ -605,7 +604,7 @@ final class EvaluationInteractorTests: XCTestCase {
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1ForceUpdate.createdAt)
         // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
-        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+        XCTAssertEqual(storage.userAttributesState.isUpdated, false, "userAttributesUpdated should be `false`")
 
         wait(for: [expectation], timeout: 0.1)
     }
@@ -676,7 +675,7 @@ final class EvaluationInteractorTests: XCTestCase {
         XCTAssertEqual(storage.featureTag, config.featureTag)
         XCTAssertEqual(storage.evaluatedAt, UserEvaluations.mock1UpsertAndArchivedFeature.createdAt)
         // because `userAttributesUpdated` == true before fetch new evaluations, now it should be `false`
-        XCTAssertEqual(storage.userAttributesUpdated, false, "userAttributesUpdated should be `false`")
+        XCTAssertEqual(storage.userAttributesState.isUpdated, false, "userAttributesUpdated should be `false`")
 
         wait(for: [expectation], timeout: 0.1)
     }

--- a/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
+++ b/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
@@ -126,8 +126,8 @@ final class EvaluationStorageImplConcurrencyTests: XCTestCase {
         // 6. Start Read Operation (Queue B)
         var readResult: Evaluation?
         readQueue.async {
-            // With the "Two Locks" strategy, this should NOT block on the write lock.
-            // It should acquire the cache lock (which is free) and return the current (old) value immediately.
+            // This should NOT block on the write lock.
+            // Acquire the cache and return the current (old) value immediately.
             readResult = storage.getBy(featureId: newEval.featureId)
             readFinishedExpectation.fulfill()
         }

--- a/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
+++ b/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
@@ -166,12 +166,12 @@ private class BlockingRealSQLDao: EvaluationSQLDao {
             try block()
 
             // Pause here! We are now inside the transaction and holding the Storage lock.
-            // This simulates the time window where SQL is updated but Cache is not yet updated.
+            // This simulates the time window after SQL operations have run but before the transaction commits and before the Cache is updated.
             if let expectation = continueWriteExpectation {
                 let result = XCTWaiter.wait(for: [expectation], timeout: 2.0)
-                                if result != .completed {
-                                    XCTFail("BlockingRealSQLDao: wait for continueWriteExpectation failed with result: \(result)")
-                                }
+                if result != .completed {
+                    XCTFail("BlockingRealSQLDao: wait for continueWriteExpectation failed with result: \(result)")
+                }
             }
         }
     }

--- a/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
+++ b/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
@@ -1,0 +1,172 @@
+import XCTest
+@testable import Bucketeer
+
+final class EvaluationStorageImplConcurrencyTests: XCTestCase {
+    let url = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent("evaluation_test.db")
+    var path: String { url.path }
+
+    override func setUp() async throws {
+        try await super.setUp()
+
+        let db = try SQLite(path: path, logger: nil)
+
+        let evaluationTable = SQLite.Table(entity: EvaluationEntity())
+        let evaluationSql = evaluationTable.sqlToCreate()
+        try db.exec(query: evaluationSql)
+    }
+
+    override func tearDown() async throws {
+        try FileManager.default.removeItem(at: url)
+
+        try await super.tearDown()
+    }
+
+    // Test 1: Integration test - Thread-safety for concurrent read/write access
+    func testConcurrentReadAndWriteSafety() throws {
+        let db = try SQLite(path: path, logger: nil)
+        let storage = EvaluationStorageImpl(
+            userId: "test_user_id",
+            evaluationDao: EvaluationSQLDaoImpl(db: db),
+            evaluationMemCacheDao: EvaluationMemCacheDao(),
+            evaluationUserDefaultsDao: EvaluationUserDefaultDaoImpl(defaults: UserDefaults.standard)
+        )
+
+        let expectation = self.expectation(description: "Concurrent read/write operations should complete without crashing")
+        expectation.expectedFulfillmentCount = 2
+
+        let iterations = 1000
+        let writeQueue = DispatchQueue(label: "io.bucketeer.sdk.queue", qos: .userInitiated)
+        let readQueue = DispatchQueue(label: "main.queue.simulation", qos: .userInteractive)
+
+        writeQueue.async {
+            for i in 0..<iterations {
+                try? storage.deleteAllAndInsert(
+                    evaluationId: "eval_id_\(i)",
+                    evaluations: [],
+                    evaluatedAt: "\(Date().timeIntervalSince1970)"
+                )
+            }
+            expectation.fulfill()
+        }
+
+        readQueue.async {
+            for _ in 0..<iterations {
+                _ = storage.getBy(featureId: "target_feature_id")
+            }
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0, handler: nil)
+    }
+
+    // Test 2: Atomicity of compound operations (SQL + UserDefaults + Cache)
+//    func testAtomicityOfCompoundOperations() {
+//        let blockingSQLDao = BlockingMockSQLDao()
+//        let memCacheDao = MockEvaluationMemCacheDao()
+//        let userDefaultsDao = MockEvaluationUserDefaultsDao()
+//
+//        let storage = EvaluationStorageImpl(
+//            userId: "test_user",
+//            evaluationDao: blockingSQLDao,
+//            evaluationMemCacheDao: memCacheDao,
+//            evaluationUserDefaultsDao: userDefaultsDao
+//        )
+//
+//        let oldEval = Evaluation.mock(id: "old_eval", featureId: "target_feature", value: "old_value")
+//        memCacheDao.set(key: "test_user", value: [oldEval])
+//        let newEval = Evaluation.mock(id: "new_eval", featureId: "target_feature", value: "new_value")
+//
+//        let writeStartedExpectation = expectation(description: "Write operation started and acquired lock")
+//        let writeFinishedExpectation = expectation(description: "Write operation finished")
+//        let readFinishedExpectation = expectation(description: "Read operation finished")
+//        let continueWriteExpectation = XCTestExpectation(description: "Signal to continue write")
+//
+//        blockingSQLDao.onStartTransaction = {
+//            writeStartedExpectation.fulfill()
+//            let result = XCTWaiter.wait(for: [continueWriteExpectation], timeout: 2.0)
+//            if result != .completed { print("Test timed out waiting for signal") }
+//        }
+//
+//        let writeQueue = DispatchQueue(label: "io.bucketeer.write")
+//        let readQueue = DispatchQueue(label: "io.bucketeer.read")
+//
+//        writeQueue.async {
+//            try? storage.deleteAllAndInsert(
+//                evaluationId: "new_id",
+//                evaluations: [newEval],
+//                evaluatedAt: "12345"
+//            )
+//            writeFinishedExpectation.fulfill()
+//        }
+//
+//        wait(for: [writeStartedExpectation], timeout: 1.0)
+//
+//        var readResult: Evaluation?
+//        readQueue.async {
+//            readResult = storage.getBy(featureId: "target_feature")
+//            readFinishedExpectation.fulfill()
+//        }
+//
+//        usleep(50_000)
+//        continueWriteExpectation.fulfill()
+//        wait(for: [writeFinishedExpectation, readFinishedExpectation], timeout: 1.0)
+//
+//        XCTAssertEqual(readResult?.id, "new_eval", "Read operation should have been blocked until Write completed, ensuring no stale data was read.")
+//        XCTAssertEqual(memCacheDao.get(key: "test_user")?.first?.id, "new_eval", "Cache should be finally updated")
+//    }
+}
+
+/*
+// MARK: - Mocks
+
+private class MockEvaluationSQLDao: EvaluationSQLDao {
+    func startTransaction(block: () throws -> Void) throws { try block() }
+    func deleteAll(userId: String) throws {}
+    func put(evaluations: [Evaluation]) throws {}
+    func get(userId: String) throws -> [Evaluation] { return [] }
+}
+
+private class MockEvaluationMemCacheDao: EvaluationMemCacheDao {
+    private var cache: [String: [Evaluation]] = [:]
+    func get(key: String) -> [Evaluation]? { cache[key] }
+    func set(key: String, value: [Evaluation]) { cache[key] = value }
+}
+
+private class MockEvaluationUserDefaultsDao: EvaluationUserDefaultsDao {
+    var currentEvaluationsId: String = ""
+    var featureTag: String = ""
+    var evaluatedAt: String = ""
+    var userAttributesUpdated: Bool = false
+    func setCurrentEvaluationsId(value: String) { currentEvaluationsId = value }
+    func setFeatureTag(value: String) { featureTag = value }
+    func setEvaluatedAt(value: String) { evaluatedAt = value }
+    func setUserAttributesUpdated(value: Bool) { userAttributesUpdated = value }
+}
+
+private class BlockingMockSQLDao: EvaluationSQLDao {
+    var onStartTransaction: (() -> Void)?
+    func startTransaction(block: () throws -> Void) throws {
+        onStartTransaction?()
+        try block()
+    }
+    func deleteAll(userId: String) throws {}
+    func put(evaluations: [Evaluation]) throws {}
+    func get(userId: String) throws -> [Evaluation] { return [] }
+}
+
+private extension Evaluation {
+    static func mock(id: String, featureId: String, value: String) -> Evaluation {
+        return Evaluation(
+            id: id,
+            featureId: featureId,
+            featureVersion: 1,
+            userId: "test_user",
+            variationId: "var_id",
+            variationName: "var_name",
+            variationValue: value,
+            reason: .init(type: .default),
+            maintained: true
+        )
+    }
+}
+*/

--- a/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
+++ b/BucketeerTests/EvaluationStorageImplConcurrencyTests.swift
@@ -42,7 +42,7 @@ final class EvaluationStorageImplConcurrencyTests: XCTestCase {
                 try? storage.deleteAllAndInsert(
                     evaluationId: "eval_id_\(i)",
                     evaluations: [],
-                    evaluatedAt: "\(Date().timeIntervalSince1970)"
+                    evaluatedAt: "\(Int(Date().timeIntervalSince1970))"
                 )
             }
             expectation.fulfill()

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -242,7 +242,7 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertTrue(storage.userAttributesState.isUpdated)
         XCTAssertEqual(storage.featureTag, "featureTagForTest")
 
-        storage.clearUserAttributesUpdated(version: updatedVersion)
+        XCTAssertTrue(storage.clearUserAttributesUpdated(state: userAttributesState))
         XCTAssertFalse(storage.userAttributesState.isUpdated)
     }
 
@@ -260,16 +260,22 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertFalse(storage.userAttributesState.isUpdated)
 
         storage.setUserAttributesUpdated()
-        let userAttributesState = storage.userAttributesState
-        let updatedVersion = userAttributesState.version
-        XCTAssertTrue(storage.userAttributesState.isUpdated)
+        let firstState = storage.userAttributesState
+        XCTAssertTrue(firstState.isUpdated)
+        XCTAssertEqual(firstState.version, 1)
+
+        storage.setUserAttributesUpdated()
+        let finalState = storage.userAttributesState
+
+        XCTAssertTrue(finalState.isUpdated)
+        XCTAssertEqual(finalState.version, 2)
 
         // Attempt to clear with an incorrect version
-        storage.clearUserAttributesUpdated(version: updatedVersion + 1)
+        XCTAssertFalse(storage.clearUserAttributesUpdated(state: firstState))
         XCTAssertTrue(storage.userAttributesState.isUpdated, "userAttributesUpdated should remain true when version does not match")
 
         // Now clear with the correct version
-        storage.clearUserAttributesUpdated(version: updatedVersion)
+        XCTAssertTrue(storage.clearUserAttributesUpdated(state: finalState))
         XCTAssertFalse(storage.userAttributesState.isUpdated, "userAttributesUpdated should be false after clearing with correct version")
     }
 
@@ -302,9 +308,8 @@ final class EvaluationStorageTests: XCTestCase {
             sdkQueue.async {
                 // Simulate SDK reading version for a fetch (Read)
                 let userAttributesState = storage.userAttributesState
-                let version = userAttributesState.version
                 // Simulate SDK clearing after fetch (Read/Write)
-                storage.clearUserAttributesUpdated(version: version)
+                storage.clearUserAttributesUpdated(state: userAttributesState)
                 group.leave()
             }
 

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -227,7 +227,6 @@ final class EvaluationStorageTests: XCTestCase {
         storage.setUserAttributesUpdated()
 
         let userAttributesState = storage.userAttributesState
-        let updatedVersion = userAttributesState.version
         storage.setFeatureTag(value: "featureTagForTest")
 
         let result = try storage.update(

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -324,8 +324,10 @@ final class EvaluationStorageTests: XCTestCase {
         // Wait for all operations to complete
         let result = group.wait(timeout: .now() + 10.0)
         XCTAssertEqual(result, .success, "Test timed out")
-        // In 99.9% of runs, storage.userAttributesUpdated resolves to false, but we cannot guarantee this behavior every time due to async nature.
-        // The critical check is that the version counter matches the number of updates, proving no race conditions when incrementing.
+        // Due to the inherent race between concurrent "update" and "clear" operations, the final value of
+        // `userAttributesUpdated` can legitimately be either true or false. This test therefore only asserts
+        // that the version counter matches the number of update calls, proving there are no race conditions
+        // when incrementing the version.
         let userAttributesState = storage.userAttributesState
         XCTAssertEqual(userAttributesState.version, iterations, "Version should exactly match the number of update calls, proving no race conditions")
     }

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -221,7 +221,7 @@ final class EvaluationStorageTests: XCTestCase {
 
         XCTAssertEqual(storage.evaluatedAt, "0", "should = 0")
         XCTAssertEqual(storage.currentEvaluationsId, "")
-        XCTAssertFalse(storage.userAttributesUpdated)
+        XCTAssertFalse(storage.userAttributesState.isUpdated)
         XCTAssertEqual(storage.featureTag, "")
 
         storage.setUserAttributesUpdated()
@@ -239,11 +239,11 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertTrue(result, "update action should success")
         XCTAssertEqual(storage.evaluatedAt, "1024", "should save last evaluatedAt")
         XCTAssertEqual(storage.currentEvaluationsId, "evaluationIdForTest")
-        XCTAssertTrue(storage.userAttributesUpdated)
+        XCTAssertTrue(storage.userAttributesState.isUpdated)
         XCTAssertEqual(storage.featureTag, "featureTagForTest")
 
         storage.clearUserAttributesUpdated(version: updatedVersion)
-        XCTAssertFalse(storage.userAttributesUpdated)
+        XCTAssertFalse(storage.userAttributesState.isUpdated)
     }
 
     func testShouldOnlyClearUserAttributesUpdatedWhenVersionMatches() throws {
@@ -257,20 +257,20 @@ final class EvaluationStorageTests: XCTestCase {
             evaluationUserDefaultsDao: mockUserDefsDao
         )
 
-        XCTAssertFalse(storage.userAttributesUpdated)
+        XCTAssertFalse(storage.userAttributesState.isUpdated)
 
         storage.setUserAttributesUpdated()
         let userAttributesState = storage.userAttributesState
         let updatedVersion = userAttributesState.version
-        XCTAssertTrue(storage.userAttributesUpdated)
+        XCTAssertTrue(storage.userAttributesState.isUpdated)
 
         // Attempt to clear with an incorrect version
         storage.clearUserAttributesUpdated(version: updatedVersion + 1)
-        XCTAssertTrue(storage.userAttributesUpdated, "userAttributesUpdated should remain true when version does not match")
+        XCTAssertTrue(storage.userAttributesState.isUpdated, "userAttributesUpdated should remain true when version does not match")
 
         // Now clear with the correct version
         storage.clearUserAttributesUpdated(version: updatedVersion)
-        XCTAssertFalse(storage.userAttributesUpdated, "userAttributesUpdated should be false after clearing with correct version")
+        XCTAssertFalse(storage.userAttributesState.isUpdated, "userAttributesUpdated should be false after clearing with correct version")
     }
 
     func testSetUserAttributesUpdatedConcurrency() {

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -225,8 +225,11 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertEqual(storage.featureTag, "")
 
         storage.setUserAttributesUpdated()
-        let updatedVersion = storage.userAttributesUpdatedVersion
+
+        let userAttributesState = storage.userAttributesState
+        let updatedVersion = userAttributesState.version
         storage.setFeatureTag(value: "featureTagForTest")
+
         let result = try storage.update(
             evaluationId:"evaluationIdForTest",
             evaluations: [.mock2],
@@ -257,7 +260,8 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertFalse(storage.userAttributesUpdated)
 
         storage.setUserAttributesUpdated()
-        let updatedVersion = storage.userAttributesUpdatedVersion
+        let userAttributesState = storage.userAttributesState
+        let updatedVersion = userAttributesState.version
         XCTAssertTrue(storage.userAttributesUpdated)
 
         // Attempt to clear with an incorrect version
@@ -297,7 +301,8 @@ final class EvaluationStorageTests: XCTestCase {
             group.enter()
             sdkQueue.async {
                 // Simulate SDK reading version for a fetch (Read)
-                let version = storage.userAttributesUpdatedVersion
+                let userAttributesState = storage.userAttributesState
+                let version = userAttributesState.version
                 // Simulate SDK clearing after fetch (Read/Write)
                 storage.clearUserAttributesUpdated(version: version)
                 group.leave()
@@ -316,6 +321,7 @@ final class EvaluationStorageTests: XCTestCase {
         XCTAssertEqual(result, .success, "Test timed out")
         // In 99.9% of runs, storage.userAttributesUpdated resolves to false, but we cannot guarantee this behavior every time due to async nature.
         // The critical check is that the version counter matches the number of updates, proving no race conditions when incrementing.
-        XCTAssertEqual(storage.userAttributesUpdatedVersion, iterations, "Version should exactly match the number of update calls, proving no race conditions")
+        let userAttributesState = storage.userAttributesState
+        XCTAssertEqual(userAttributesState.version, iterations, "Version should exactly match the number of update calls, proving no race conditions")
     }
 }

--- a/BucketeerTests/EvaluationStorageTests.swift
+++ b/BucketeerTests/EvaluationStorageTests.swift
@@ -315,7 +315,7 @@ final class EvaluationStorageTests: XCTestCase {
         let result = group.wait(timeout: .now() + 10.0)
         XCTAssertEqual(result, .success, "Test timed out")
 
-        XCTAssertEqual(storage.userAttributesUpdatedVersion, iterations, "Version should increment exactly matches the number of update calls, proving no race conditions")
+        XCTAssertEqual(storage.userAttributesUpdatedVersion, iterations, "Version should exactly match the number of update calls, proving no race conditions")
         XCTAssertFalse(storage.userAttributesUpdated, "Final userAttributesUpdated state should be false after all clears")
     }
 }

--- a/BucketeerTests/InMemoryCacheTests.swift
+++ b/BucketeerTests/InMemoryCacheTests.swift
@@ -13,4 +13,92 @@ final class InMemoryCacheTests: XCTestCase {
         XCTAssertEqual(memCache.get(key: "key"), "value2")
         XCTAssertEqual(memCache.get(key: "key1"), "value1")
     }
+
+    func testConcurrentAccess() {
+        let cache = InMemoryCache<Int>()
+        let queue = DispatchQueue(label: "test.concurrent.queue", attributes: .concurrent)
+        let group = DispatchGroup()
+        let iterations = 1000
+
+        // 1. Perform many concurrent writes
+        for i in 0..<iterations {
+            group.enter()
+            queue.async {
+                cache.set(key: "key-\(i)", value: i)
+                group.leave()
+            }
+        }
+
+        // 2. Perform many concurrent reads and writes mixed together
+        for i in 0..<iterations {
+            group.enter()
+            queue.async {
+                // Randomly choose to read or write to stress test the barrier
+                if Bool.random() {
+                    cache.set(key: "shared-key", value: i)
+                } else {
+                    _ = cache.get(key: "shared-key")
+                }
+                group.leave()
+            }
+        }
+
+        // 3. Wait for all operations to complete
+        let result = group.wait(timeout: .now() + 5.0)
+
+        XCTAssertEqual(result, .success, "Concurrent operations timed out")
+
+        // 4. Verify data integrity (basic check)
+        // We know "key-0" through "key-999" should exist
+        for i in 0..<iterations {
+            XCTAssertEqual(cache.get(key: "key-\(i)"), i)
+        }
+    }
+
+    func testConcurrentAccessThreadSafety() {
+        let cache = InMemoryCache<Evaluation>()
+        // Use a concurrent queue to simulate multiple threads hitting the cache
+        let queue = DispatchQueue(label: "io.bucketeer.tests.concurrent", attributes: .concurrent)
+        let group = DispatchGroup()
+        let iterations = 2000
+
+        // 1. Populate initial data (Static keys that shouldn't change)
+        for i in 0..<100 {
+            cache.set(key: "static-key-\(i)", value: .mock1)
+        }
+
+        // 2. Stress Test: Simultaneous Reads and Writes
+        for i in 0..<iterations {
+            group.enter()
+            queue.async {
+                // Mix Reads and Writes deterministically (50/50 split)
+                if i % 2 == 0 {
+                    // WRITE: Should trigger the barrier
+                    // Toggle between two values to force memory updates
+                    let value: Evaluation = (i % 4 == 0) ? .mock1 : .mock1Updated
+                    cache.set(key: "hot-key", value: value)
+                } else {
+                    // READ: Should run in parallel (unless blocked by barrier)
+
+                    // 1. Verify static data integrity (should never be corrupted by the write barrier)
+                    let staticVal = cache.get(key: "static-key-\(i % 100)")
+                    XCTAssertEqual(staticVal?.id, Evaluation.mock1.id, "Static data corrupted during concurrent write")
+
+                    // 2. Read the hot key (value might change, but shouldn't crash)
+                    _ = cache.get(key: "hot-key")
+                }
+                group.leave()
+            }
+        }
+
+        // 3. Wait for completion
+        let result = group.wait(timeout: .now() + 10.0)
+        XCTAssertEqual(result, .success, "Test timed out. Possible deadlock in barrier logic.")
+
+        // 4. Final State Verification
+        // The 'hot-key' must be in a valid state (either mock1 or mock1Updated), not corrupted/nil.
+        let finalValue = cache.get(key: "hot-key")
+        XCTAssertNotNil(finalValue)
+        XCTAssertTrue(finalValue?.id == Evaluation.mock1.id || finalValue?.id == Evaluation.mock1Updated.id)
+    }
 }

--- a/BucketeerTests/Mock/MockDefaults.swift
+++ b/BucketeerTests/Mock/MockDefaults.swift
@@ -9,11 +9,6 @@ final class MockDefaults: Defaults {
     // Underlying storage; only access while synchronized on `queue`.
     private var _dict: [String: Any?] = [:]
 
-    private var dict: [String: Any?] {
-        get { queue.sync { _dict } }
-        set { queue.sync(flags: .barrier) { _dict = newValue } }
-    }
-
     func bool(forKey defaultName: String) -> Bool {
         return queue.sync { _dict[defaultName] as? Bool ?? false }
     }

--- a/BucketeerTests/Mock/MockDefaults.swift
+++ b/BucketeerTests/Mock/MockDefaults.swift
@@ -15,4 +15,8 @@ final class MockDefaults: Defaults {
     func set(_ value: Any?, forKey defaultName: String) {
         dict[defaultName] = value
     }
+
+    func removeObject(forKey defaultName: String) {
+        dict[defaultName] = nil
+    }
 }

--- a/BucketeerTests/Mock/MockDefaults.swift
+++ b/BucketeerTests/Mock/MockDefaults.swift
@@ -2,21 +2,31 @@ import Foundation
 @testable import Bucketeer
 
 final class MockDefaults: Defaults {
-    func bool(forKey defaultName: String) -> Bool {
-        return dict[defaultName] as? Bool ?? false
+    // Use a concurrent queue so multiple readers can run concurrently.
+    // Writes must be exclusive, so use barrier flags to serialize them and ensure visibility.
+    private let queue = DispatchQueue(label: "com.bucketeer.mockdefaults.queue", attributes: .concurrent)
+
+    // Underlying storage; only access while synchronized on `queue`.
+    private var _dict: [String: Any?] = [:]
+
+    private var dict: [String: Any?] {
+        get { queue.sync { _dict } }
+        set { queue.sync(flags: .barrier) { _dict = newValue } }
     }
 
-    var dict: [String: Any?] = [:]
+    func bool(forKey defaultName: String) -> Bool {
+        return queue.sync { _dict[defaultName] as? Bool ?? false }
+    }
 
     func string(forKey defaultName: String) -> String? {
-        return dict[defaultName] as? String
+        return queue.sync { _dict[defaultName] as? String }
     }
 
     func set(_ value: Any?, forKey defaultName: String) {
-        dict[defaultName] = value
+        queue.sync(flags: .barrier) { _dict[defaultName] = value }
     }
 
     func removeObject(forKey defaultName: String) {
-        dict[defaultName] = nil
+        queue.sync(flags: .barrier) { _dict[defaultName] = nil }
     }
 }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -54,6 +54,8 @@ final class MockEvaluationStorage: EvaluationStorage {
     let refreshCacheHandler: RefreshCacheHandler?
     let userId: String
     var setUserAttributesUpdatedLock = NSLock()
+    // protected by setUserAttributesUpdatedLock
+    private var userAttributesUpdatedVersion: Int = 0
 
     init(userId: String,
          getHandler: GetHandler? = nil,
@@ -129,16 +131,6 @@ final class MockEvaluationStorage: EvaluationStorage {
                 version: userAttributesUpdatedVersion,
                 isUpdated: userAttributesUpdated
             )
-        }
-    }
-
-    private var userAttributesUpdatedVersion: Int = 0
-
-    func clearUserAttributesUpdated(version: Int) {
-        setUserAttributesUpdatedLock.withLock {
-            if userAttributesUpdatedVersion == version {
-                userAttributesUpdated = false
-            }
         }
     }
 

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -30,15 +30,6 @@ final class MockEvaluationStorage: EvaluationStorage {
         }
     }
 
-    var userAttributesUpdated: Bool {
-        get {
-            return evaluationUserDefaultsDao.userAttributesUpdated
-        }
-        set {
-            evaluationUserDefaultsDao.userAttributesUpdated = newValue
-        }
-    }
-
     typealias PutHandler = ((String, [Evaluation]) throws -> Void)
     typealias GetHandler = () throws -> [Evaluation]
     typealias DeleteAllAndInsertHandler = ([Evaluation]) throws -> Void
@@ -56,6 +47,14 @@ final class MockEvaluationStorage: EvaluationStorage {
     var setUserAttributesUpdatedLock = NSLock()
     // protected by setUserAttributesUpdatedLock
     private var userAttributesUpdatedVersion: Int = 0
+    private var userAttributesUpdated: Bool {
+        get {
+            return evaluationUserDefaultsDao.userAttributesUpdated
+        }
+        set {
+            evaluationUserDefaultsDao.userAttributesUpdated = newValue
+        }
+    }
 
     init(userId: String,
          getHandler: GetHandler? = nil,

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -141,4 +141,15 @@ final class MockEvaluationStorage: EvaluationStorage {
             }
         }
     }
+
+    func clearUserAttributesUpdated(state: UserAttributesState) -> Bool {
+        guard state.isUpdated else { return false }
+        return setUserAttributesUpdatedLock.withLock {
+            if userAttributesUpdatedVersion == state.version {
+                userAttributesUpdated = false
+                return true
+            }
+            return false
+        }
+    }
 }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -53,7 +53,7 @@ final class MockEvaluationStorage: EvaluationStorage {
     let evaluationUserDefaultsDao = MockEvaluationUserDefaultsDao()
     let refreshCacheHandler: RefreshCacheHandler?
     let userId: String
-    var userAttributesUpdatedLock = NSLock()
+    var setUserAttributesUpdatedLock = NSLock()
 
     init(userId: String,
          getHandler: GetHandler? = nil,
@@ -112,14 +112,10 @@ final class MockEvaluationStorage: EvaluationStorage {
         evaluatedAt = value
     }
 
-    private func setUserAttributesUpdated(value: Bool) {
-        userAttributesUpdated = value
-    }
-
     func setUserAttributesUpdated() {
-        userAttributesUpdatedLock.withLock {
-            userAttributesUpdatedVersion += 1
-            setUserAttributesUpdated(value: true)
+        setUserAttributesUpdatedLock.withLock {
+            _userAttributesUpdatedVersion += 1
+            userAttributesUpdated = true
         }
     }
 
@@ -127,12 +123,18 @@ final class MockEvaluationStorage: EvaluationStorage {
         currentEvaluationsId = ""
     }
 
-    var userAttributesUpdatedVersion: Int = 0
+    var userAttributesUpdatedVersion: Int {
+        return setUserAttributesUpdatedLock.withLock {
+            return _userAttributesUpdatedVersion
+        }
+    }
+    
+    private var _userAttributesUpdatedVersion: Int = 0
 
     func clearUserAttributesUpdated(version: Int) {
-        userAttributesUpdatedLock.withLock {
-            if userAttributesUpdatedVersion == version {
-                setUserAttributesUpdated(value: false)
+        setUserAttributesUpdatedLock.withLock {
+            if _userAttributesUpdatedVersion == version {
+                userAttributesUpdated = false
             }
         }
     }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -114,7 +114,7 @@ final class MockEvaluationStorage: EvaluationStorage {
 
     func setUserAttributesUpdated() {
         setUserAttributesUpdatedLock.withLock {
-            _userAttributesUpdatedVersion += 1
+            userAttributesUpdatedVersion += 1
             userAttributesUpdated = true
         }
     }
@@ -123,17 +123,20 @@ final class MockEvaluationStorage: EvaluationStorage {
         currentEvaluationsId = ""
     }
 
-    var userAttributesUpdatedVersion: Int {
+    var userAttributesState: UserAttributesState {
         return setUserAttributesUpdatedLock.withLock {
-            return _userAttributesUpdatedVersion
+            return UserAttributesState(
+                version: userAttributesUpdatedVersion,
+                isUpdated: userAttributesUpdated
+            )
         }
     }
 
-    private var _userAttributesUpdatedVersion: Int = 0
+    private var userAttributesUpdatedVersion: Int = 0
 
     func clearUserAttributesUpdated(version: Int) {
         setUserAttributesUpdatedLock.withLock {
-            if _userAttributesUpdatedVersion == version {
+            if userAttributesUpdatedVersion == version {
                 userAttributesUpdated = false
             }
         }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -53,6 +53,7 @@ final class MockEvaluationStorage: EvaluationStorage {
     let evaluationUserDefaultsDao = MockEvaluationUserDefaultsDao()
     let refreshCacheHandler: RefreshCacheHandler?
     let userId: String
+    var userAttributesUpdatedLock = NSLock()
 
     init(userId: String,
          getHandler: GetHandler? = nil,
@@ -116,14 +117,23 @@ final class MockEvaluationStorage: EvaluationStorage {
     }
 
     func setUserAttributesUpdated() {
-        setUserAttributesUpdated(value: true)
-    }
-
-    func clearUserAttributesUpdated() {
-        setUserAttributesUpdated(value: false)
+        userAttributesUpdatedLock.withLock {
+            userAttributesUpdatedVersion += 1
+            setUserAttributesUpdated(value: true)
+        }
     }
 
     func clearCurrentEvaluationsId() {
         currentEvaluationsId = ""
+    }
+
+    var userAttributesUpdatedVersion: Int = 0
+
+    func clearUserAttributesUpdated(version: Int) {
+        userAttributesUpdatedLock.withLock {
+            if userAttributesUpdatedVersion == version {
+                setUserAttributesUpdated(value: false)
+            }
+        }
     }
 }

--- a/BucketeerTests/Mock/MockEvaluationStorage.swift
+++ b/BucketeerTests/Mock/MockEvaluationStorage.swift
@@ -128,7 +128,7 @@ final class MockEvaluationStorage: EvaluationStorage {
             return _userAttributesUpdatedVersion
         }
     }
-    
+
     private var _userAttributesUpdatedVersion: Int = 0
 
     func clearUserAttributesUpdated(version: Int) {


### PR DESCRIPTION
This PR introduces thread-safe user attribute update tracking and improves overall concurrency handling in the evaluation system.

### Main changes:
- Fixed [a logical race condition related to userAttributesUpdated](https://github.com/bucketeer-io/ios-client-sdk/pull/116#issuecomment-3729063265) by introducing a versioned User Attributes State.
The boolean userAttributesUpdated flag is replaced with a UserAttributesState struct containing a version counter and an update flag. This prevents race conditions where concurrent attribute updates could be lost during in-flight fetch operations. The clearing logic now uses an atomic compare-and-swap based on version matching.

- Fixed a potential race condition when reading evaluations that could cause a runtime crash.
This is addressed by implementing a thread-safe InMemoryCache using a concurrent queue with barrier synchronization, ensuring safe reads and writes without blocking the main thread.

### Test infrastructure for fix some flaky tests fail
- Added a deleteAll() method to EvaluationUserDefaultDaoImpl for centralized test cleanup.
- Ensured evaluation storage access in tests uses the correct dispatch queue to maintain thread safety.


