### PR TITLE
fix: latency metrics should reflect only the most recent (final) network request attempt

### DIFF
--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -144,6 +144,7 @@ final class ApiClientImpl: ApiClient {
     ///   - path: The API endpoint path to append to the base URL
     ///   - timeoutMillis: Request timeout in milliseconds
     ///   - encoder: JSON encoder for the request body (default: JSONEncoder())
+    ///   - onAttemptStart: Optional callback invoked at the start of every network attempt (initial and retries).
     ///   - completion: Callback with the result of the request
     ///
     /// - Retry Behavior:

--- a/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
+++ b/Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift
@@ -53,7 +53,7 @@ final class ApiClientImpl: ApiClient {
         timeoutMillis: Int64?,
         condition: UserEvaluationCondition,
         completion: ((GetEvaluationsResult) -> Void)?) {
-        let startAt = Date()
+        var startAt = Date()
         let requestBody = GetEvaluationsRequestBody(
             tag: self.featureTag,
             user: user,
@@ -76,6 +76,7 @@ final class ApiClientImpl: ApiClient {
             requestBody: requestBody,
             path: ApiPaths.getEvaluations.rawValue,
             timeoutMillis: timeoutMillisValue,
+            onAttemptStart: { startAt = Date() },
             completion: { (result: Result<(GetEvaluationsResponse, URLResponse), Error>) in
                 switch result {
                 case .success((var response, let urlResponse)):
@@ -159,6 +160,7 @@ final class ApiClientImpl: ApiClient {
         path: String,
         timeoutMillis: Int64,
         encoder: JSONEncoder = JSONEncoder(),
+        onAttemptStart: (() -> Void)? = nil,
         completion: ((Result<(Response, URLResponse), Error>) -> Void)?) {
             // weak self - we don't want to retain ApiClientImpl in the retrier task closure
             // if ApiClientImpl is deallocated, the task will not be executed
@@ -186,6 +188,8 @@ final class ApiClientImpl: ApiClient {
                         ))
                         return
                     }
+
+                    onAttemptStart?()
 
                     self?.sendInternal(
                         requestBody: requestBody,

--- a/BucketeerTests/ApiClientLatencyTests.swift
+++ b/BucketeerTests/ApiClientLatencyTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Bucketeer
 
+// swiftlint:disable type_body_length
 /// Regression tests for the "duration is nil and latencySecond is 0" backend
 /// warning, applied to the iOS SDK.
 ///
@@ -243,4 +244,181 @@ class ApiClientLatencyTests: XCTestCase {
             "expected at least one fast mock response to measure between 0 and 1ms; observed: \(observed)"
         )
     }
+
+    // MARK: - Latency correctness with retries
+
+    // seconds reflects only the final attempt after one 499 retry (1 s backoff excluded)
+    func testGetEvaluationsLatencyReflectsOnlyFinalAttemptAfterOneRetry() throws {
+        let userEvaluationsId = "user_evaluation_retry1"
+        let successResponse = GetEvaluationsResponse(
+            evaluations: .init(
+                id: userEvaluationsId,
+                evaluations: [.mock1],
+                createdAt: "1",
+                forceUpdate: false,
+                archivedFeatureIds: []
+            ),
+            userEvaluationsId: userEvaluationsId
+        )
+        let successData = try JSONEncoder().encode(successResponse)
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.latency.retry1")
+
+        var session = MockSession(
+            configuration: .default,
+            data: Data("".utf8),
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
+                statusCode: 499,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, count in
+            let statusCode = count == 1 ? 499 : 200
+            let data = count == 1 ? Data("".utf8) : successData
+            return MockResponseData(
+                data: data,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: "1.2.3"),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "latency excludes 1 s backoff after one retry")
+        let totalStart = Date()
+
+        mockDispatchQueue.async {
+            api.getEvaluations(
+                user: .mock1,
+                userEvaluationsId: userEvaluationsId,
+                condition: UserEvaluationCondition(
+                    evaluatedAt: "0",
+                    userAttributesUpdated: false
+                )
+            ) { result in
+                switch result {
+                case .success(let response):
+                    let totalElapsed = Date().timeIntervalSince(totalStart)
+                    XCTAssertGreaterThan(response.seconds, 0)
+                    XCTAssertTrue(response.seconds.isFinite)
+                    // totalElapsed >= 1.0 s due to backoff; seconds should only measure the
+                    // final attempt (sub-ms). A gap of > 0.8 s is a robust safety margin.
+                    XCTAssertLessThan(
+                        response.seconds,
+                        totalElapsed - 0.8,
+                        "seconds (\(response.seconds)) should exclude the ~1 s backoff; totalElapsed = \(totalElapsed)"
+                    )
+                case .failure(let error, _):
+                    XCTFail("unexpected failure: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    // seconds reflects only the final attempt after two 499 retries (1 s + 2 s backoff excluded)
+    func testGetEvaluationsLatencyReflectsOnlyFinalAttemptAfterTwoRetries() throws {
+        let userEvaluationsId = "user_evaluation_retry2"
+        let successResponse = GetEvaluationsResponse(
+            evaluations: .init(
+                id: userEvaluationsId,
+                evaluations: [.mock1],
+                createdAt: "1",
+                forceUpdate: false,
+                archivedFeatureIds: []
+            ),
+            userEvaluationsId: userEvaluationsId
+        )
+        let successData = try JSONEncoder().encode(successResponse)
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.latency.retry2")
+
+        var session = MockSession(
+            configuration: .default,
+            data: Data("".utf8),
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
+                statusCode: 499,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, count in
+            let statusCode = count < 3 ? 499 : 200
+            let data = count < 3 ? Data("".utf8) : successData
+            return MockResponseData(
+                data: data,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: "1.2.3"),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "latency excludes 1 s + 2 s backoff after two retries")
+        let totalStart = Date()
+
+        mockDispatchQueue.async {
+            api.getEvaluations(
+                user: .mock1,
+                userEvaluationsId: userEvaluationsId,
+                condition: UserEvaluationCondition(
+                    evaluatedAt: "0",
+                    userAttributesUpdated: false
+                )
+            ) { result in
+                switch result {
+                case .success(let response):
+                    let totalElapsed = Date().timeIntervalSince(totalStart)
+                    XCTAssertGreaterThan(response.seconds, 0)
+                    XCTAssertTrue(response.seconds.isFinite)
+                    // totalElapsed >= 3.0 s due to 1 s + 2 s backoff; seconds should only measure
+                    // the final attempt (sub-ms). A gap of > 2.5 s is a robust safety margin.
+                    XCTAssertLessThan(
+                        response.seconds,
+                        totalElapsed - 2.5,
+                        "seconds (\(response.seconds)) should exclude the ~3 s total backoff; totalElapsed = \(totalElapsed)"
+                    )
+                case .failure(let error, _):
+                    XCTFail("unexpected failure: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 10)
+    }
 }
+// swiftlint:enable type_body_length

--- a/BucketeerTests/ApiClientLatencyTests.swift
+++ b/BucketeerTests/ApiClientLatencyTests.swift
@@ -264,17 +264,7 @@ class ApiClientLatencyTests: XCTestCase {
         let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
         let mockDispatchQueue = DispatchQueue(label: "test.queue.latency.retry1")
 
-        var session = MockSession(
-            configuration: .default,
-            data: Data("".utf8),
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
-                statusCode: 499,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, count in
             let statusCode = count == 1 ? 499 : 200
             let data = count == 1 ? Data("".utf8) : successData
@@ -351,17 +341,7 @@ class ApiClientLatencyTests: XCTestCase {
         let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
         let mockDispatchQueue = DispatchQueue(label: "test.queue.latency.retry2")
 
-        var session = MockSession(
-            configuration: .default,
-            data: Data("".utf8),
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(ApiPaths.getEvaluations.rawValue),
-                statusCode: 499,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, count in
             let statusCode = count < 3 ? 499 : 200
             let data = count < 3 ? Data("".utf8) : successData

--- a/BucketeerTests/ApiClientRetriableTests.swift
+++ b/BucketeerTests/ApiClientRetriableTests.swift
@@ -817,17 +817,7 @@ class ApiClientRetriableTests: XCTestCase {
         let path = ApiPaths.getEvaluations.rawValue
         let mockDispatchQueue = DispatchQueue(label: "test.queue.tc1")
 
-        var session = MockSession(
-            configuration: .default,
-            data: mockResponse,
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(path),
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, _ in
             return MockResponseData(
                 data: mockResponse,
@@ -851,8 +841,10 @@ class ApiClientRetriableTests: XCTestCase {
             logger: nil
         )
 
-        let expectation = XCTestExpectation(description: "onAttemptStart called once on first-attempt success")
-        var callCount = 0
+        let completionExpectation = XCTestExpectation(description: "completion called once")
+        let attemptExpectation = XCTestExpectation(description: "onAttemptStart called once")
+        attemptExpectation.expectedFulfillmentCount = 1
+        attemptExpectation.assertForOverFulfill = true
 
         mockDispatchQueue.async {
             let requestId = UUID()
@@ -862,20 +854,20 @@ class ApiClientRetriableTests: XCTestCase {
                 requestBody: MockRequestBody(),
                 path: path,
                 timeoutMillis: 100,
-                onAttemptStart: { callCount += 1 },
+                onAttemptStart: { attemptExpectation.fulfill() },
                 completion: { (result: Result<(MockResponse, URLResponse), Error>) in
                     switch result {
                     case .success:
-                        XCTAssertEqual(callCount, 1, "onAttemptStart should be called exactly once")
+                        break
                     case .failure(let error):
                         XCTFail("should not fail: \(error)")
                     }
-                    expectation.fulfill()
+                    completionExpectation.fulfill()
                 }
             )
         }
 
-        wait(for: [expectation], timeout: 2)
+        wait(for: [completionExpectation, attemptExpectation], timeout: 2)
     }
 
     // callback fires once per attempt — 499 then 200 (2 calls total)
@@ -885,17 +877,7 @@ class ApiClientRetriableTests: XCTestCase {
         let path = ApiPaths.getEvaluations.rawValue
         let mockDispatchQueue = DispatchQueue(label: "test.queue.tc2")
 
-        var session = MockSession(
-            configuration: .default,
-            data: Data("".utf8),
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(path),
-                statusCode: 499,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, count in
             let statusCode = count == 1 ? 499 : 200
             let data = count == 1 ? Data("".utf8) : mockResponse
@@ -921,8 +903,10 @@ class ApiClientRetriableTests: XCTestCase {
             logger: nil
         )
 
-        let expectation = XCTestExpectation(description: "onAttemptStart called twice for 499 then 200")
-        var callCount = 0
+        let completionExpectation = XCTestExpectation(description: "completion called once")
+        let attemptExpectation = XCTestExpectation(description: "onAttemptStart called once per attempt")
+        attemptExpectation.expectedFulfillmentCount = 2
+        attemptExpectation.assertForOverFulfill = true
 
         mockDispatchQueue.async {
             let requestId = UUID()
@@ -932,21 +916,20 @@ class ApiClientRetriableTests: XCTestCase {
                 requestBody: MockRequestBody(),
                 path: path,
                 timeoutMillis: 100,
-                onAttemptStart: { callCount += 1 },
+                onAttemptStart: { attemptExpectation.fulfill() },
                 completion: { (result: Result<(MockResponse, URLResponse), Error>) in
                     switch result {
                     case .success:
-                        XCTAssertEqual(callCount, 2, "onAttemptStart should be called once per attempt")
                         XCTAssertEqual(session.requestCount(), 2, "Should attempt exactly 2 times")
                     case .failure(let error):
                         XCTFail("should not fail: \(error)")
                     }
-                    expectation.fulfill()
+                    completionExpectation.fulfill()
                 }
             )
         }
 
-        wait(for: [expectation], timeout: 5)
+        wait(for: [completionExpectation, attemptExpectation], timeout: 5)
     }
 
     // callback fires once per attempt — 499, 499, then 200 (3 calls total)
@@ -956,17 +939,7 @@ class ApiClientRetriableTests: XCTestCase {
         let path = ApiPaths.getEvaluations.rawValue
         let mockDispatchQueue = DispatchQueue(label: "test.queue.tc3")
 
-        var session = MockSession(
-            configuration: .default,
-            data: Data("".utf8),
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(path),
-                statusCode: 499,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, count in
             let statusCode = count < 3 ? 499 : 200
             let data = count < 3 ? Data("".utf8) : mockResponse
@@ -992,8 +965,10 @@ class ApiClientRetriableTests: XCTestCase {
             logger: nil
         )
 
-        let expectation = XCTestExpectation(description: "onAttemptStart called three times for 499, 499, then 200")
-        var callCount = 0
+        let completionExpectation = XCTestExpectation(description: "completion called once")
+        let attemptExpectation = XCTestExpectation(description: "onAttemptStart called once per attempt")
+        attemptExpectation.expectedFulfillmentCount = 3
+        attemptExpectation.assertForOverFulfill = true
 
         mockDispatchQueue.async {
             let requestId = UUID()
@@ -1003,21 +978,20 @@ class ApiClientRetriableTests: XCTestCase {
                 requestBody: MockRequestBody(),
                 path: path,
                 timeoutMillis: 100,
-                onAttemptStart: { callCount += 1 },
+                onAttemptStart: { attemptExpectation.fulfill() },
                 completion: { (result: Result<(MockResponse, URLResponse), Error>) in
                     switch result {
                     case .success:
-                        XCTAssertEqual(callCount, 3, "onAttemptStart should be called once per attempt")
                         XCTAssertEqual(session.requestCount(), 3, "Should attempt exactly 3 times")
                     case .failure(let error):
                         XCTFail("should not fail: \(error)")
                     }
-                    expectation.fulfill()
+                    completionExpectation.fulfill()
                 }
             )
         }
 
-        wait(for: [expectation], timeout: 8)
+        wait(for: [completionExpectation, attemptExpectation], timeout: 8)
     }
 
     // omitting onAttemptStart (default nil) does not crash or alter normal behaviour
@@ -1027,17 +1001,7 @@ class ApiClientRetriableTests: XCTestCase {
         let path = ApiPaths.registerEvents.rawValue
         let mockDispatchQueue = DispatchQueue(label: "test.queue.tc4")
 
-        var session = MockSession(
-            configuration: .default,
-            data: mockResponse,
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(path),
-                statusCode: 200,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, _ in
             return MockResponseData(
                 data: mockResponse,
@@ -1093,17 +1057,7 @@ class ApiClientRetriableTests: XCTestCase {
         let path = ApiPaths.getEvaluations.rawValue
         let mockDispatchQueue = DispatchQueue(label: "test.queue.tc5")
 
-        var session = MockSession(
-            configuration: .default,
-            data: Data("".utf8),
-            response: HTTPURLResponse(
-                url: apiEndpointURL.appendingPathComponent(path),
-                statusCode: 499,
-                httpVersion: nil,
-                headerFields: nil
-            ),
-            error: nil
-        )
+        var session = MockSession(configuration: .default)
         session.responseProvider = { _, _ in
             return MockResponseData(
                 data: Data("".utf8),
@@ -1128,8 +1082,11 @@ class ApiClientRetriableTests: XCTestCase {
             logger: nil
         )
 
-        let expectation = XCTestExpectation(description: "onAttemptStart not called for cancelled retry")
-        var callCount = 0
+        let completionExpectation = XCTestExpectation(description: "completion called once after cancellation")
+        // assertForOverFulfill catches any extra onAttemptStart calls (e.g. a retry that should be cancelled)
+        let attemptExpectation = XCTestExpectation(description: "onAttemptStart called only for initial attempt")
+        attemptExpectation.expectedFulfillmentCount = 1
+        attemptExpectation.assertForOverFulfill = true
 
         mockDispatchQueue.async {
             let requestId = UUID()
@@ -1139,7 +1096,7 @@ class ApiClientRetriableTests: XCTestCase {
                 requestBody: MockRequestBody(),
                 path: path,
                 timeoutMillis: 100,
-                onAttemptStart: { callCount += 1 },
+                onAttemptStart: { attemptExpectation.fulfill() },
                 completion: { (result: Result<(MockResponse, URLResponse), Error>) in
                     switch result {
                     case .success:
@@ -1151,11 +1108,8 @@ class ApiClientRetriableTests: XCTestCase {
                             return
                         }
                         XCTAssertEqual(message, "Request cancelled by newer execution")
-                        // Only the initial attempt should have fired onAttemptStart;
-                        // the retry was cancelled before the callback was reached.
-                        XCTAssertEqual(callCount, 1, "onAttemptStart must not be called for a cancelled retry")
                     }
-                    expectation.fulfill()
+                    completionExpectation.fulfill()
                 }
             )
         }
@@ -1166,7 +1120,7 @@ class ApiClientRetriableTests: XCTestCase {
             api.setEvaluationsRequestId(UUID())
         }
 
-        wait(for: [expectation], timeout: 5)
+        wait(for: [completionExpectation, attemptExpectation], timeout: 5)
     }
 }
 // swiftlint:enable type_body_length file_length

--- a/BucketeerTests/ApiClientRetriableTests.swift
+++ b/BucketeerTests/ApiClientRetriableTests.swift
@@ -807,5 +807,366 @@ class ApiClientRetriableTests: XCTestCase {
 
         wait(for: [expectation], timeout: 5)
     }
+
+    // MARK: - onAttemptStart callback tests
+
+    // callback fires exactly once when the first attempt succeeds
+    func testOnAttemptStartCalledOnceWhenFirstAttemptSucceeds() throws {
+        let mockResponse = try JSONEncoder().encode(MockResponse())
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = ApiPaths.getEvaluations.rawValue
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.tc1")
+
+        var session = MockSession(
+            configuration: .default,
+            data: mockResponse,
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, _ in
+            return MockResponseData(
+                data: mockResponse,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(path),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "onAttemptStart called once on first-attempt success")
+        var callCount = 0
+
+        mockDispatchQueue.async {
+            let requestId = UUID()
+            api.setEvaluationsRequestId(requestId)
+            api.send(
+                requestId: requestId,
+                requestBody: MockRequestBody(),
+                path: path,
+                timeoutMillis: 100,
+                onAttemptStart: { callCount += 1 },
+                completion: { (result: Result<(MockResponse, URLResponse), Error>) in
+                    switch result {
+                    case .success:
+                        XCTAssertEqual(callCount, 1, "onAttemptStart should be called exactly once")
+                    case .failure(let error):
+                        XCTFail("should not fail: \(error)")
+                    }
+                    expectation.fulfill()
+                }
+            )
+        }
+
+        wait(for: [expectation], timeout: 2)
+    }
+
+    // callback fires once per attempt — 499 then 200 (2 calls total)
+    func testOnAttemptStartCalledOncePerAttemptWith499ThenSuccess() throws {
+        let mockResponse = try JSONEncoder().encode(MockResponse())
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = ApiPaths.getEvaluations.rawValue
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.tc2")
+
+        var session = MockSession(
+            configuration: .default,
+            data: Data("".utf8),
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 499,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, count in
+            let statusCode = count == 1 ? 499 : 200
+            let data = count == 1 ? Data("".utf8) : mockResponse
+            return MockResponseData(
+                data: data,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(path),
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "onAttemptStart called twice for 499 then 200")
+        var callCount = 0
+
+        mockDispatchQueue.async {
+            let requestId = UUID()
+            api.setEvaluationsRequestId(requestId)
+            api.send(
+                requestId: requestId,
+                requestBody: MockRequestBody(),
+                path: path,
+                timeoutMillis: 100,
+                onAttemptStart: { callCount += 1 },
+                completion: { (result: Result<(MockResponse, URLResponse), Error>) in
+                    switch result {
+                    case .success:
+                        XCTAssertEqual(callCount, 2, "onAttemptStart should be called once per attempt")
+                        XCTAssertEqual(session.requestCount(), 2, "Should attempt exactly 2 times")
+                    case .failure(let error):
+                        XCTFail("should not fail: \(error)")
+                    }
+                    expectation.fulfill()
+                }
+            )
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
+
+    // callback fires once per attempt — 499, 499, then 200 (3 calls total)
+    func testOnAttemptStartCalledOncePerAttemptWithMultipleRetries() throws {
+        let mockResponse = try JSONEncoder().encode(MockResponse())
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = ApiPaths.getEvaluations.rawValue
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.tc3")
+
+        var session = MockSession(
+            configuration: .default,
+            data: Data("".utf8),
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 499,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, count in
+            let statusCode = count < 3 ? 499 : 200
+            let data = count < 3 ? Data("".utf8) : mockResponse
+            return MockResponseData(
+                data: data,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(path),
+                    statusCode: statusCode,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "onAttemptStart called three times for 499, 499, then 200")
+        var callCount = 0
+
+        mockDispatchQueue.async {
+            let requestId = UUID()
+            api.setEvaluationsRequestId(requestId)
+            api.send(
+                requestId: requestId,
+                requestBody: MockRequestBody(),
+                path: path,
+                timeoutMillis: 100,
+                onAttemptStart: { callCount += 1 },
+                completion: { (result: Result<(MockResponse, URLResponse), Error>) in
+                    switch result {
+                    case .success:
+                        XCTAssertEqual(callCount, 3, "onAttemptStart should be called once per attempt")
+                        XCTAssertEqual(session.requestCount(), 3, "Should attempt exactly 3 times")
+                    case .failure(let error):
+                        XCTFail("should not fail: \(error)")
+                    }
+                    expectation.fulfill()
+                }
+            )
+        }
+
+        wait(for: [expectation], timeout: 8)
+    }
+
+    // omitting onAttemptStart (default nil) does not crash or alter normal behaviour
+    func testSendWorksNormallyWhenOnAttemptStartIsNil() throws {
+        let mockResponse = try JSONEncoder().encode(MockResponse())
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = ApiPaths.registerEvents.rawValue
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.tc4")
+
+        var session = MockSession(
+            configuration: .default,
+            data: mockResponse,
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, _ in
+            return MockResponseData(
+                data: mockResponse,
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(path),
+                    statusCode: 200,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "send works normally without onAttemptStart")
+
+        mockDispatchQueue.async {
+            let requestId = UUID()
+            api.setRegisterEventsRequestId(requestId)
+            // No onAttemptStart passed — uses default nil
+            api.send(
+                requestId: requestId,
+                requestBody: MockRequestBody(),
+                path: path,
+                timeoutMillis: 100
+            ) { (result: Result<(MockResponse, URLResponse), Error>) in
+                switch result {
+                case .success((let response, _)):
+                    XCTAssertEqual(response.value, "response")
+                    XCTAssertEqual(session.requestCount(), 1, "Should only attempt once")
+                case .failure(let error):
+                    XCTFail("should not fail: \(error)")
+                }
+                expectation.fulfill()
+            }
+        }
+
+        wait(for: [expectation], timeout: 2)
+    }
+
+    // onAttemptStart is NOT called for a retry that is cancelled by a newer request ID
+    func testOnAttemptStartNotCalledWhenRequestCancelledByNewerExecution() throws {
+        let apiEndpointURL = URL(string: "https://test.bucketeer.io")!
+        let path = ApiPaths.getEvaluations.rawValue
+        let mockDispatchQueue = DispatchQueue(label: "test.queue.tc5")
+
+        var session = MockSession(
+            configuration: .default,
+            data: Data("".utf8),
+            response: HTTPURLResponse(
+                url: apiEndpointURL.appendingPathComponent(path),
+                statusCode: 499,
+                httpVersion: nil,
+                headerFields: nil
+            ),
+            error: nil
+        )
+        session.responseProvider = { _, _ in
+            return MockResponseData(
+                data: Data("".utf8),
+                response: HTTPURLResponse(
+                    url: apiEndpointURL.appendingPathComponent(path),
+                    statusCode: 499,
+                    httpVersion: nil,
+                    headerFields: nil
+                ),
+                error: nil
+            )
+        }
+
+        let api = ApiClientImpl(
+            apiEndpoint: apiEndpointURL,
+            apiKey: "x:api-key",
+            featureTag: "tag1",
+            sdkInfo: SDKInfo(sourceId: .ios, sdkVersion: Version.current),
+            defaultRequestTimeoutMillis: 200,
+            session: session,
+            retrier: Retrier(queue: mockDispatchQueue),
+            logger: nil
+        )
+
+        let expectation = XCTestExpectation(description: "onAttemptStart not called for cancelled retry")
+        var callCount = 0
+
+        mockDispatchQueue.async {
+            let requestId = UUID()
+            api.setEvaluationsRequestId(requestId)
+            api.send(
+                requestId: requestId,
+                requestBody: MockRequestBody(),
+                path: path,
+                timeoutMillis: 100,
+                onAttemptStart: { callCount += 1 },
+                completion: { (result: Result<(MockResponse, URLResponse), Error>) in
+                    switch result {
+                    case .success:
+                        XCTFail("should not succeed")
+                    case .failure(let error):
+                        guard let bktError = error as? BKTError,
+                              case .illegalState(let message) = bktError else {
+                            XCTFail("expected BKTError.illegalState, got: \(error)")
+                            return
+                        }
+                        XCTAssertEqual(message, "Request cancelled by newer execution")
+                        // Only the initial attempt should have fired onAttemptStart;
+                        // the retry was cancelled before the callback was reached.
+                        XCTAssertEqual(callCount, 1, "onAttemptStart must not be called for a cancelled retry")
+                    }
+                    expectation.fulfill()
+                }
+            )
+        }
+
+        // The first attempt fires and returns 499. Backoff takes ~1 s before the retry.
+        // Update the request ID after 0.1 s so the retry sees a mismatch and cancels.
+        mockDispatchQueue.asyncAfter(deadline: .now() + 0.1) {
+            api.setEvaluationsRequestId(UUID())
+        }
+
+        wait(for: [expectation], timeout: 5)
+    }
 }
 // swiftlint:enable type_body_length file_length


### PR DESCRIPTION

refs: https://github.com/bucketeer-io/javascript-client-sdk/pull/325

This pull request enhances the `ApiClientImpl` retry mechanism by introducing a new `onAttemptStart` callback, which is invoked at the beginning of each network attempt (including retries). This allows for more accurate tracking of request latency and enables external observers to react to each attempt. The PR also adds comprehensive tests to verify the correct behavior of the callback and to ensure that latency measurements exclude retry backoff periods.

**Enhancements to retry and latency tracking:**

* Added an `onAttemptStart` optional callback parameter to the `ApiClientImpl.send` method, which is called at the start of every network attempt, including retries. This enables precise measurement of request latency and allows external actions to be triggered for each attempt. (`Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift`) [[1]](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eR147) [[2]](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eR164) [[3]](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eR193-R194)
* Updated the `getEvaluations` method to use the new `onAttemptStart` callback, ensuring that the latency timer is reset for each attempt, not just the initial one. (`Bucketeer/Sources/Internal/Remote/ApiClientImpl.swift`) [[1]](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eL56-R56) [[2]](diffhunk://#diff-b08b550636108a5a48448145fc1db8e9bcf7bb1314563fabfedd2cee6be82d3eR79)

**Testing improvements:**

* Added new regression tests to ensure that reported latency (`seconds`) reflects only the duration of the final attempt, excluding any backoff time from retries. These tests cover scenarios with one and two retries. (`BucketeerTests/ApiClientLatencyTests.swift`)
* Added a suite of tests to verify the behavior of the `onAttemptStart` callback, including cases with no retries, multiple retries, omitted callbacks, and cancellation by newer requests. (`BucketeerTests/ApiClientRetriableTests.swift`)

These changes improve the reliability and observability of the API client's retry logic, making it easier to monitor and reason about network request timing and behavior.