### PR TITLE
ci: pin Xcode 16.2 in upload-framework workflow

### DIFF
--- a/.github/workflows/upload-framework.yml
+++ b/.github/workflows/upload-framework.yml
@@ -6,6 +6,9 @@ on:
     tags:
       - v*
 
+env:
+  XCODE_VERSION: '16.2'
+
 jobs:
   upload-xcframework:
     runs-on: macos-14-xlarge
@@ -14,6 +17,9 @@ jobs:
       MINT_LINK_PATH: ${{ github.workspace }}/mint/bin
     steps:
       - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
 
       - name: Install bootstrap mint
         uses: irgaly/setup-mint@99eaad2ad1197ea872390322a47620da2f21fde4 # v1.4.0


### PR DESCRIPTION
The `upload-xcframeowork` workflow had no Xcode selection step and fell back to the
runner's default (15.4), causing `make create-xcframework-zip` to
fail. Align it with the other workflows that select 16.2.

https://github.com/bucketeer-io/ios-client-sdk/actions/runs/25776889860/job/75711321756