### PR TITLE
fix: build failure when using scipio to build the sdk as an xcframework

### DIFF
--- a/.github/workflows/build-xcframework-scipio.yml
+++ b/.github/workflows/build-xcframework-scipio.yml
@@ -1,0 +1,53 @@
+name: Verify XCFramework (Scipio)
+
+# Xcode 26.2 (Swift 6.1) is required for Scipio; Xcode 16.2 did not work with it.
+# Uses a separate Mint cache key (mint-packages-plus-scipio-*) so it does not
+# interfere with the cache used by other workflows.
+
+on:
+  workflow_dispatch:
+  push:
+    paths-ignore:
+      - '*.md'
+      - '.github/**'
+    branches:
+      - main
+
+env:
+  XCODE_VERSION: '26.2'
+
+jobs:
+  scipio-xcframework:
+    runs-on: macos-15-xlarge
+    steps:
+      - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4.3.0
+
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_${{ env.XCODE_VERSION }}.app/Contents/Developer'
+
+      - name: Cache Mint packages
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.mint
+            ~/Library/Caches/Mint
+            ~/Library/Developer/Xcode/DerivedData
+            ~/.swiftpm
+          key: ${{ runner.os }}-mint-packages-plus-scipio-${{ hashFiles('**/Mintfile') }}-v1
+          restore-keys: |
+            ${{ runner.os }}-mint-packages-plus-scipio-${{ hashFiles('**/Mintfile') }}-
+            ${{ runner.os }}-mint-packages-plus-scipio-
+
+      - name: Setup Mint
+        uses: irgaly/setup-mint@a109d74bd0d8f27bc2b921853461ffd17cf6bd89 # v1.8.0
+        with:
+          bootstrap: true
+          bootstrap-link: true
+          use-cache: true
+          cache-prefix: "mint-plus-scipio-setup-v1"
+          clean: true
+
+      - name: Build XCFramework with Scipio
+        env:
+          CI: true
+        run: make create-xcframework-scipio

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ DerivedData/
 # save directory to frameworks at "create_xcframework" run
 FrameworkBuild/
 
+# Scipio XCFramework output (verification build, not published)
+XCFrameworks/
+
 ## Various settings
 *.pbxuser
 !default.pbxuser

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationMemCacheDao.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 protocol KeyValueCache {
     associatedtype DataCacheType
     func set(key: String, value: DataCacheType)

--- a/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
+++ b/Bucketeer/Sources/Internal/Evaluation/EvaluationStorageImpl.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 final class EvaluationStorageImpl: EvaluationStorage {
 
     var currentEvaluationsId: String {

--- a/Makefile
+++ b/Makefile
@@ -109,6 +109,10 @@ generate-project-file:
 create-xcframework-zip:
 	./hack/create-xcframework.sh --zip
 
+.PHONY: create-xcframework-scipio
+create-xcframework-scipio:
+	./hack/create-xcframework-scipio.sh --run
+
 .PHONY: sort-proj
 sort-proj:
 	./hack/sort-Xcode-project-file $(APP_NAME).xcodeproj

--- a/README.md
+++ b/README.md
@@ -107,6 +107,26 @@ Run E2E Tests
 make e2e-without-building
 ```
 
+### Export XCFramework
+
+There are two ways to build and export the XCFramework.
+
+**Option 1 — via Xcode archive (default)**
+
+Uses the standard `xcodebuild` archive approach.
+
+```sh
+make create-xcframework-zip
+```
+
+**Option 2 — via [Scipio](https://github.com/giginet/Scipio)**
+
+Requires Xcode 26.2+ (Swift 6.1). Uses Scipio to build the XCFramework directly from the Swift package.
+
+```sh
+make create-xcframework-scipio
+```
+
 ## Example App
 
 To run the example app.

--- a/hack/create-xcframework-scipio.sh
+++ b/hack/create-xcframework-scipio.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+function run() {
+    if [ "$CI" = "" ]; then
+        export MINT_LINK_PATH="$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH="$MINT_LIBRARY_PATH_AT_INSTALL"
+    else
+        export MINT_LINK_PATH=".$MINT_LINK_PATH_AT_INSTALL"
+        export MINT_PATH=".$MINT_LIBRARY_PATH_AT_INSTALL"
+    fi
+
+    command_output=$(mint which scipio 2>&1)
+    exit_status=$?
+
+    if [ $exit_status -ne 0 ]; then
+        echo "Scipio didn't find. $command_output"
+        mint install giginet/Scipio
+    fi
+    mint run scipio create . \
+        --support-simulators \
+        --enable-library-evolution \
+        --overwrite \
+        --output XCFrameworks
+}
+
+if [ ${#@} -eq 1 ]; then
+    if [ "${@#"-r"}" = "" ] || [ "${@#"--run"}" = "" ]; then
+        run
+    fi
+fi


### PR DESCRIPTION
## Problem

Starting from v2.3.0, when using [Scipio](https://github.com/giginet/Scipio)
to build Bucketeer as an XCFramework encounter a build failure:

- `EvaluationMemCacheDao.swift` uses `DispatchQueue` without `import Foundation`
- `EvaluationStorageImpl.swift` uses `NSLock` without `import Foundation`

These types were introduced as part of the thread-safety changes in
b88f0a3 (v2.3.0), but the required `import Foundation` was omitted.

## Root Cause

Builds via `xcodebuild` against `Bucketeer.xcodeproj` succeed because
Xcode propagates `Foundation` implicitly through its framework linkage
and module maps — so `DispatchQueue` and `NSLock` resolve without an
explicit import.

Scipio also uses `xcodebuild`, but it generates a **temporary project
from `Package.swift`** rather than using `.xcodeproj`. This generated
project has no inherited framework linkage or implicit module maps, so
each file must explicitly declare every dependency it uses. Without
`import Foundation`, `DispatchQueue` and `NSLock` are unresolved
identifiers.

This is why `make create-xcframework-zip` succeeds (uses `.xcodeproj`)
while Scipio fails (derives from `Package.swift`).

> Note: standard SPM consumers resolving the package through Xcode are
> **not** affected — Xcode still provides implicit imports even for
> SPM-sourced targets. Only `Package.swift`-derived isolated builds
> (Scipio, `swift build` CLI) are impacted.

## Fix

- Add `import Foundation` explicitly to both files. This is the correct
per-spec behavior regardless — relying on implicit transitive imports
is fragile and happens to work in Xcode only as a convenience.
- Add a Github Action to test build using Scipio