### PR TITLE
ci(workflow): trigger xcframework build on pull requests

### DIFF
--- a/.github/workflows/build-xcframework-scipio.yml
+++ b/.github/workflows/build-xcframework-scipio.yml
@@ -12,6 +12,12 @@ on:
       - '.github/**'
     branches:
       - main
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - '.github/**'
+      - Bucketeer/Sources/Internal/Utils/Version.swift
+      - Bucketeer.podspec
 
 env:
   XCODE_VERSION: '26.2'


### PR DESCRIPTION
We should run xcframework build before merging to find the issue in the early stage